### PR TITLE
Add csv content import

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Django Test
+      run: |
+        ./manage.py test --settings=contentrepo.settings.base   

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ GitHub.sublime-settings
 !.vscode/launch.json
 !.vscode/extensions.json
 .history
+
+.DS_Store

--- a/home/management/commands/import_csv_content.py
+++ b/home/management/commands/import_csv_content.py
@@ -36,9 +36,10 @@ class Command(BaseCommand):
                     messenger_body=get_body(row[8]),
                     viber_title=row[9],
                     viber_subtitle=row[10],
-                    viber_body=get_body(row[11])
+                    viber_body=get_body(row[11]),
+                    tags=row[12].split(" ")
                 )
                 home_page.add_child(instance=contentpage)
-                contentpage.save()
+                contentpage.save_revision()
 
             self.stdout.write(self.style.SUCCESS('Successfully imported Content Pages'))

--- a/home/management/commands/import_csv_content.py
+++ b/home/management/commands/import_csv_content.py
@@ -2,6 +2,7 @@ import csv
 from django.core.management.base import BaseCommand, CommandError
 from home.models import ContentPage, HomePage
 from wagtail.core.rich_text import RichText
+from taggit.models import Tag
 
 
 class Command(BaseCommand):
@@ -18,6 +19,12 @@ class Command(BaseCommand):
                 if len(line) != 0:
                     body = body + [('paragraph', RichText(line))]
             return body
+
+        def create_tags(row, page):
+            tags = row[12].split(" ")
+            for tag in tags:
+                created_tag, _ = Tag.objects.get_or_create(name=tag)
+                page.tags.add(created_tag)
 
         path = options['path']
         home_page = HomePage.objects.first()
@@ -37,8 +44,8 @@ class Command(BaseCommand):
                     viber_title=row[9],
                     viber_subtitle=row[10],
                     viber_body=get_body(row[11]),
-                    tags=row[12].split(" ")
                 )
+                create_tags(row, contentpage)
                 home_page.add_child(instance=contentpage)
                 contentpage.save_revision()
 

--- a/home/management/commands/import_csv_content.py
+++ b/home/management/commands/import_csv_content.py
@@ -1,0 +1,44 @@
+import csv
+from django.core.management.base import BaseCommand, CommandError
+from home.models import ContentPage, HomePage
+from wagtail.core.rich_text import RichText
+
+
+class Command(BaseCommand):
+    help = 'Imports content via CSV'
+
+    def add_arguments(self, parser):
+        parser.add_argument('path')
+
+    def handle(self, *args, **options):
+        def get_body(row):
+            body = []
+            row = row.splitlines()
+            for line in row:
+                if len(line) != 0:
+                    body = body + [('paragraph', RichText(line))]
+            return body
+
+        path = options['path']
+        home_page = HomePage.objects.first()
+        with open(path, 'rt') as f:
+            reader = csv.reader(f)
+            for row in reader:
+                contentpage = ContentPage(
+                    title=row[0],
+                    subtitle=row[1],
+                    body=get_body(row[2]),
+                    whatsapp_title=row[3],
+                    whatsapp_subtitle=row[4],
+                    whatsapp_body=get_body(row[5]),
+                    messenger_title=row[6],
+                    messenger_subtitle=row[7],
+                    messenger_body=get_body(row[8]),
+                    viber_title=row[9],
+                    viber_subtitle=row[10],
+                    viber_body=get_body(row[11])
+                )
+                home_page.add_child(instance=contentpage)
+                contentpage.save()
+
+            self.stdout.write(self.style.SUCCESS('Successfully imported Content Pages'))

--- a/home/tests/content2.csv
+++ b/home/tests/content2.csv
@@ -1,0 +1,5 @@
+Web Title 1,Web subtitle 1,"This is a nice body
+
+<h2>With two paragraphs</h2>",Whatsapp Title 1,Whatsapp Subtitle 1,Whatsapp Body 1,Messenger Title 1,Messenger subtitle 1,Messenger Body 1,Viber Title 1,Viber subtitle 1,Viber body 1,tag1 tag2
+Web Title 2,Web subtitle 2,Web body 2,Whatsapp Title 2,Whatsapp Subtitle 2,Whatsapp Body 2,Messenger Title 2,Messenger subtitle 2,Messenger Body 2,Viber Title 2,Viber subtitle 2,Viber body 2,
+Web Title 3,Web subtitle 3,Web body 3,Whatsapp Title 3,Whatsapp Subtitle 3,Whatsapp Body 3,Messenger Title 3,Messenger subtitle 3,,Viber Title 3,Viber subtitle 3,Viber body 3,

--- a/home/tests/test_csv_import.py
+++ b/home/tests/test_csv_import.py
@@ -1,0 +1,46 @@
+from django.core.management import call_command
+from django.test import TestCase
+from home.models import ContentPage
+
+
+class CSVImportTestCase(TestCase):
+
+    def test_csv_import(self):
+        "Tests importing content via csv management command"
+
+        # assert no content pages exist
+        self.assertEquals(ContentPage.objects.count(), 0)
+
+        args = ["home/tests/content2.csv"]
+        opts = {}
+        call_command('import_csv_content', *args, **opts)
+
+        # assert 3 content pages were created
+        self.assertEquals(ContentPage.objects.count(), 3)
+
+        page_1 = ContentPage.objects.first()
+        page_3 = ContentPage.objects.last()
+
+        # assert 3 correct titles
+        self.assertEquals(page_1.title, "Web Title 1")
+        self.assertEquals(page_3.title, "Web Title 3")
+
+        # assert correct rich text blocks with markdown
+        self.assertEquals(
+            str(page_1.body[0].render()),
+            "This is a nice body"
+        )
+        self.assertEquals(
+            str(page_1.body[1].render()),
+            "<h2>With two paragraphs</h2>"
+        )
+        self.assertEquals(
+            page_3.whatsapp_body[0].render(),
+            "Whatsapp Body 3"
+        )
+
+
+        # assert correct tags
+
+        # assert handles empty csv field
+        self.assertEquals(len(page_3.messenger_body), 0)

--- a/home/tests/test_csv_import.py
+++ b/home/tests/test_csv_import.py
@@ -39,8 +39,9 @@ class CSVImportTestCase(TestCase):
             "Whatsapp Body 3"
         )
 
-
         # assert correct tags
+        self.assertEquals(page_1.tags.first().name, "tag1")
+        self.assertEquals(page_1.tags.last().name, "tag2")
 
         # assert handles empty csv field
         self.assertEquals(len(page_3.messenger_body), 0)


### PR DESCRIPTION
## Purpose
_The purpose of this PR is to be able to import content via CSV_

## Approach
_We did this via adding a management command that accepts a CSV and turns it into content. Each row is a new content page with each column a different page field._

#### Open Questions and Pre-Merge TODOs
- [x] Allow blank spaces
- [x] Allow multiple lines
- [x] Allow markdown
- [x] Allow Tags
- [ ] Allow Images
