### PR TITLE
Import content via JSON

### DIFF
--- a/home/management/commands/import_json_content.py
+++ b/home/management/commands/import_json_content.py
@@ -1,5 +1,6 @@
 import json
 from django.core.management.base import BaseCommand
+from taggit.models import Tag
 from home.models import ContentPage, HomePage
 from wagtail.core.rich_text import RichText
 
@@ -18,6 +19,11 @@ class Command(BaseCommand):
                     body = body + [('paragraph', RichText(line))]
             return body
 
+        def create_tags(tags, page):
+            for tag in tags:
+                created_tag, _ = Tag.objects.get_or_create(name=tag)
+                page.tags.add(created_tag)
+
         path = options['path']
         home_page = HomePage.objects.first()
         with open(path) as json_file:
@@ -26,8 +32,9 @@ class Command(BaseCommand):
                 contentpage = ContentPage(
                     title=article[0],
                     subtitle=article[1],
-                    body=get_body(article[2]),
+                    body=get_body(article[2])
                 )
+                create_tags(article[3], contentpage)
                 home_page.add_child(instance=contentpage)
                 contentpage.save_revision()
 

--- a/home/management/commands/import_json_content.py
+++ b/home/management/commands/import_json_content.py
@@ -30,11 +30,11 @@ class Command(BaseCommand):
             data = json.load(json_file)
             for article in data["articles"]:
                 contentpage = ContentPage(
-                    title=article[0],
-                    subtitle=article[1],
-                    body=get_body(article[2])
+                    title=article["title"],
+                    subtitle=article["subtitle"],
+                    body=get_body(article["body"])
                 )
-                create_tags(article[3], contentpage)
+                create_tags(article["tags"], contentpage)
                 home_page.add_child(instance=contentpage)
                 contentpage.save_revision()
 

--- a/home/management/commands/import_json_content.py
+++ b/home/management/commands/import_json_content.py
@@ -1,0 +1,34 @@
+import json
+from django.core.management.base import BaseCommand
+from home.models import ContentPage, HomePage
+from wagtail.core.rich_text import RichText
+
+
+class Command(BaseCommand):
+    help = 'Imports content via JSON'
+
+    def add_arguments(self, parser):
+        parser.add_argument('path')
+
+    def handle(self, *args, **options):
+        def get_body(body_list):
+            body = []
+            for line in body_list:
+                if len(line) != 0:
+                    body = body + [('paragraph', RichText(line))]
+            return body
+
+        path = options['path']
+        home_page = HomePage.objects.first()
+        with open(path) as json_file:
+            data = json.load(json_file)
+            for article in data["articles"]:
+                contentpage = ContentPage(
+                    title=article[0],
+                    subtitle=article[1],
+                    body=get_body(article[2]),
+                )
+                home_page.add_child(instance=contentpage)
+                contentpage.save_revision()
+
+            self.stdout.write(self.style.SUCCESS('Successfully imported Content Pages'))

--- a/home/tests/output.json
+++ b/home/tests/output.json
@@ -1,0 +1,1 @@
+{"articles": [["article title", "article subtitle", ["<p>this is some plain text</p>", "<p>this is some richtext</p>"]]]}

--- a/home/tests/output.json
+++ b/home/tests/output.json
@@ -1,1 +1,1 @@
-{"articles": [["article title", "article subtitle", ["<p>this is some plain text</p>", "<p>this is some richtext</p>"], ["tag1", "tag2"]]]}
+{"articles": [{"title": "article title", "subtitle": "article subtitle", "body": ["<p>this is some plain text</p>", "<p>this is some richtext</p>"], "tags": ["tag1", "tag2"]}]}

--- a/home/tests/output.json
+++ b/home/tests/output.json
@@ -1,1 +1,1 @@
-{"articles": [["article title", "article subtitle", ["<p>this is some plain text</p>", "<p>this is some richtext</p>"]]]}
+{"articles": [["article title", "article subtitle", ["<p>this is some plain text</p>", "<p>this is some richtext</p>"], ["tag1", "tag2"]]]}

--- a/home/tests/test_json_import.py
+++ b/home/tests/test_json_import.py
@@ -1,0 +1,35 @@
+from django.core.management import call_command
+from django.test import TestCase
+from home.models import ContentPage
+
+
+class JSONImportTestCase(TestCase):
+
+    def test_csv_import(self):
+        "Tests importing content via json management command"
+
+        # assert no content pages exist
+        self.assertEquals(ContentPage.objects.count(), 0)
+
+        args = ["home/tests/output.json"]
+        opts = {}
+        call_command('import_json_content', *args, **opts)
+
+        # assert 1 content page were created
+        self.assertEquals(ContentPage.objects.count(), 1)
+
+        page_1 = ContentPage.objects.first()
+
+        # assert corect title and subtitle
+        self.assertEquals(page_1.title, "article title")
+        self.assertEquals(page_1.subtitle, "article subtitle")
+
+        # assert correct rich text blocks
+        self.assertEquals(
+            str(page_1.body[0].render()),
+            "<p>this is some plain text</p>"
+        )
+        self.assertEquals(
+            page_1.body[1].render(),
+            "<p>this is some richtext</p>"
+        )

--- a/home/tests/test_json_import.py
+++ b/home/tests/test_json_import.py
@@ -5,7 +5,7 @@ from home.models import ContentPage
 
 class JSONImportTestCase(TestCase):
 
-    def test_csv_import(self):
+    def test_json_import(self):
         "Tests importing content via json management command"
 
         # assert no content pages exist

--- a/home/tests/test_json_import.py
+++ b/home/tests/test_json_import.py
@@ -33,3 +33,7 @@ class JSONImportTestCase(TestCase):
             page_1.body[1].render(),
             "<p>this is some richtext</p>"
         )
+
+        # assert correct tags
+        self.assertEquals(page_1.tags.first().name, "tag1")
+        self.assertEquals(page_1.tags.last().name, "tag2")


### PR DESCRIPTION
## Purpose
_Import content from one CMS to another_

## Approach
_The quickest and easiest way for us to do this is to add a script to existing project that exports desired fields to json, and then run a management command to import it on the content repo_
