### PR TITLE
Add API docs

### DIFF
--- a/contentrepo/settings/base.py
+++ b/contentrepo/settings/base.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'drf_spectacular',
 ]
 
 MIDDLEWARE = [
@@ -163,3 +164,12 @@ WAGTAILCONTENTIMPORT_DEFAULT_MAPPER = 'home.mappers.ContentMapper'
 #         }
 #     }
 # }
+
+REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'ContentRepo API',
+    'VERSION': '1.0.0',
+}

--- a/contentrepo/urls.py
+++ b/contentrepo/urls.py
@@ -12,15 +12,29 @@ from wagtail_content_import import urls as wagtail_content_import_urls
 from search import views as search_views
 from home.api import api_router
 
+from django.views.generic import TemplateView
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView
+)
+
 
 urlpatterns = [
     path('django-admin/', admin.site.urls),
     path('', include(wagtail_content_import_urls)),
     path('admin/', include(wagtailadmin_urls)),
     path('documents/', include(wagtaildocs_urls)),
-
     path('search/', search_views.search, name='search'),
-
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path(
+        'api/schema/swagger-ui/',
+        SpectacularSwaggerView.as_view(url_name='schema'),
+        name='swagger-ui'),
+    path(
+        'api/schema/redoc/',
+        SpectacularRedocView.as_view(url_name='schema'),
+        name='redoc'),
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ wagtail==2.13
 psycopg2-binary
 wagtail-content-import
 django-redis
+drf-spectacular


### PR DESCRIPTION
## Purpose
_Add API documentation._

## Approach
_It is not possible to create API documentation using the DRF tutorials with Wagtail as outlined [here](https://github.com/wagtail/wagtail/issues/6209). The approach I took was to follow the application linked in this issue and allow swagger and ReDoc API docs. This application is well maintained. _

