### PR TITLE
Content import with a newline (message break) argument

### DIFF
--- a/home/management/commands/import_csv_content.py
+++ b/home/management/commands/import_csv_content.py
@@ -1,5 +1,4 @@
 import csv
-from email.policy import default
 from wagtail.core import blocks
 from django.core.management.base import BaseCommand
 from home.models import ContentPage, HomePage
@@ -80,6 +79,7 @@ class Command(BaseCommand):
 
         if options["purge"] == "yes":
             ContentPage.objects.all().delete()
+
         path = options["path"]
         home_page = HomePage.objects.first()
         with open(path, "rt") as f:

--- a/home/management/commands/import_csv_content.py
+++ b/home/management/commands/import_csv_content.py
@@ -1,4 +1,5 @@
 import csv
+from email.policy import default
 from wagtail.core import blocks
 from django.core.management.base import BaseCommand
 from home.models import ContentPage, HomePage
@@ -13,6 +14,7 @@ class Command(BaseCommand):
         parser.add_argument("--path")
         parser.add_argument("--splitmessages", default="yes")
         parser.add_argument("--purge", default="no")
+        parser.add_argument("--newline", default=False)
 
     def handle(self, *args, **options):
         def get_rich_text_body(row):
@@ -26,7 +28,10 @@ class Command(BaseCommand):
         def get_text_body(raw):
             if options["splitmessages"] == "yes":
                 struct_blocks = []
-                rows = raw.splitlines()
+                if options["newline"]:
+                    rows = raw.split(options["newline"])
+                else:
+                    rows = raw.splitlines()
                 for row in rows:
                     if row:
                         block = blocks.StructBlock(
@@ -75,7 +80,6 @@ class Command(BaseCommand):
 
         if options["purge"] == "yes":
             ContentPage.objects.all().delete()
-
         path = options["path"]
         home_page = HomePage.objects.first()
         with open(path, "rt") as f:

--- a/home/tests/content_newlines.csv
+++ b/home/tests/content_newlines.csv
@@ -1,0 +1,4 @@
+web_title,web_subtitle,web_body,whatsapp_title,whatsapp_subtitle,whatsapp_body,messenger_title,messenger_subtitle,messenger_body,viber_title,viber_subtitle,viber_body,tags,parent
+Web Title 1,Web subtitle 1,"web body",Whatsapp Title 1,Whatsapp Subtitle 1,"First whatsapp message
+====
+second whatsapp message",Messenger Title 1,Messenger subtitle 1,Messenger Body 1,Viber Title 1,Viber subtitle 1,Viber body 1,"tag1,tag2",

--- a/home/tests/test_csv_import.py
+++ b/home/tests/test_csv_import.py
@@ -41,3 +41,25 @@ class CSVImportTestCase(TestCase):
 
         # assert handles empty csv field
         self.assertEquals(len(page_3.messenger_body), 0)
+
+    def test_import_csv_with_newline(self):
+        # Assert no content pages exist
+        self.assertEquals(ContentPage.objects.count(), 0)
+
+        args = ["--path", "home/tests/content_newlines.csv", "--newline", "===="]
+        opts = {}
+        call_command("import_csv_content", *args, **opts)
+
+        # Assert 1 content page was created
+        self.assertEquals(ContentPage.objects.count(), 1)
+        page = ContentPage.objects.first()
+
+        # Assert the title is correct
+        self.assertEquals(page.title, "Web Title 1")
+
+        # Assert whatsapp is enabled 
+        self.assertTrue(page.enable_whatsapp)
+
+        # Assert the first and second messages split between "===="
+        self.assertTrue(str(page.whatsapp_body[0].render()), "First whatsapp message")
+        self.assertTrue(str(page.whatsapp_body[1].render()), "second whatsapp message")

--- a/home/tests/test_csv_import.py
+++ b/home/tests/test_csv_import.py
@@ -57,7 +57,7 @@ class CSVImportTestCase(TestCase):
         # Assert the title is correct
         self.assertEquals(page.title, "Web Title 1")
 
-        # Assert whatsapp is enabled 
+        # Assert whatsapp is enabled
         self.assertTrue(page.enable_whatsapp)
 
         # Assert the first and second messages split between "===="


### PR DESCRIPTION
During the uploading of the OOY content, the only options for split messages was yes which splits each line into another message with `splitlines()`, or no, which results in only one message. We needed the OOY content to break in certain places to stop WhatsApp giving a "read more" link. 

I added an argument called newlines to the `import_csv_content` which breaks WhatsApp content into new messages (As I type this I realise my naming was terrible and it should probably change, maybe `messagebreak`?. Suggestions are welcomed). This allows me to set them to break into new messages on the custom message break `====`. I will also add a test if these changes are accepted. 

If there is another way to do this, please let me know. 
I also wasn't sure if this functionality was necessary for web pages. 