### PR TITLE
Upgrade Django 3 to 4.0

### DIFF
--- a/contentrepo/settings/dev.py
+++ b/contentrepo/settings/dev.py
@@ -7,7 +7,12 @@ DEBUG = True
 SECRET_KEY = os.environ.get("SECRET_KEY", DEFAULT_SECRET_KEY)
 
 # SECURITY WARNING: define the correct hosts in production!
-ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "localhost")
+ALLOWED_HOSTS = os.environ.get(
+    "ALLOWED_HOSTS",
+    [
+        "localhost",
+    ],
+)
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=3.2,<3.3
+Django>=4.0,<4.1
 wagtail==2.16.2
 wagtailmedia
 psycopg2-binary


### PR DESCRIPTION
## Purpose
_Updating Django from 3 to 4.0 so that we can upgrade wagtail to version 3_


#### Blog Posts
- [Django 4.0 release notes](https://docs.djangoproject.com/en/4.0/releases/4.0/) 
