### PR TITLE
Upgrade wagtail to v3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=4.0,<4.1
-wagtail==2.16.2
+wagtail>=3.0,<3.1
 wagtailmedia
 psycopg2-binary
 wagtail-content-import


### PR DESCRIPTION
## Purpose
_Upgrading Wagtail from 2.16 to 3.0._

#### Blog Posts
- [Wagtail 3.0 release notes](https://docs.wagtail.org/en/stable/releases/3.0.html) 