### PR TITLE
Remove panel ratings from promotional tab on content page to work on fix

### DIFF
--- a/home/panels.py
+++ b/home/panels.py
@@ -5,8 +5,9 @@ class PageRatingPanel(Panel):
     class BoundPanel(Panel.BoundPanel):
         template_name = "panels/page_rating_panel.html"
 
-        def get_context_data(self, parent_context=None):
-            context = super().get_context_data(parent_context)
-            context["page_value"] = self.instance.page_rating
-            context["revision_value"] = self.instance.latest_revision_rating
-            return context
+        # def get_context_data(self, parent_context=None):
+        #     context = super().get_context_data(parent_context)
+        #     if self.instance:
+        #         context["page_value"] = self.instance.page_rating
+        #         context["revision_value"] = self.instance.latest_revision_rating
+        #     return context


### PR DESCRIPTION
Creating new content page broken due to page rating panels. Removing functionality to find a fix 