### PR TITLE
Fix page ratings such that a new page can be created

### DIFF
--- a/home/panels.py
+++ b/home/panels.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import Panel
 
 
@@ -11,6 +12,6 @@ class PageRatingPanel(Panel):
                 context["page_value"] = self.instance.page_rating
                 context["revision_value"] = self.instance.latest_revision_rating
             else:
-                context["page_value"] = "(No ratings yet)"
-                context["revision_value"] = "(No revisions yet)"
+                context["page_value"] = _("(No ratings yet)")
+                context["revision_value"] = _("(No revisions yet)")
             return context

--- a/home/panels.py
+++ b/home/panels.py
@@ -5,9 +5,12 @@ class PageRatingPanel(Panel):
     class BoundPanel(Panel.BoundPanel):
         template_name = "panels/page_rating_panel.html"
 
-        # def get_context_data(self, parent_context=None):
-        #     context = super().get_context_data(parent_context)
-        #     if self.instance:
-        #         context["page_value"] = self.instance.page_rating
-        #         context["revision_value"] = self.instance.latest_revision_rating
-        #     return context
+        def get_context_data(self, parent_context=None):
+            context = super().get_context_data(parent_context)
+            if self.instance.id:
+                context["page_value"] = self.instance.page_rating
+                context["revision_value"] = self.instance.latest_revision_rating
+            else:
+                context["page_value"] = "(No ratings yet)"
+                context["revision_value"] = "(No revisions yet)"
+            return context

--- a/home/templates/panels/page_rating_panel.html
+++ b/home/templates/panels/page_rating_panel.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <ul class="fields"><li><div style="padding-top: 1.2em;">
-    Page: </div>{{page_value}}<div style="padding-top: 1.2em;">
-    Latest Revision: </div>{{revision_value}}</li></ul>
+    {% translate 'Page:' %} </div>{{page_value}}<div style="padding-top: 1.2em;">
+        {% translate 'Latest Revision:' %} </div>{{revision_value}}</li></ul>


### PR DESCRIPTION
Pages could not be created because although `self.instance` existed, it had no ID assigned, thus page ratings will only be fetched if the content page model has an ID assigned to it 