### PR TITLE
Dont save whatsapp messages if validation fails 

### DIFF
--- a/contentrepo/settings/base.py
+++ b/contentrepo/settings/base.py
@@ -18,6 +18,7 @@ INSTALLED_APPS = [
     "menu",
     "wagtail.contrib.forms",
     "wagtail.contrib.redirects",
+    "wagtail.contrib.settings",
     "wagtail.embeds",
     "wagtail.sites",
     "wagtail.users",

--- a/home/models.py
+++ b/home/models.py
@@ -40,6 +40,10 @@ class WhatsappBlock(blocks.StructBlock):
         max_length=20, help_text="prompt text for next message", required=False
     )
 
+    class Meta:
+        icon = "user"
+        form_classname = "whatsapp-message-block struct-block"
+
 
 class ViberBlock(blocks.StructBlock):
     image = ImageChooserBlock(required=False)

--- a/home/models.py
+++ b/home/models.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db import models
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
@@ -38,10 +39,6 @@ class WhatsappBlock(blocks.StructBlock):
     next_prompt = blocks.CharBlock(
         max_length=20, help_text="prompt text for next message", required=False
     )
-
-    class Meta:
-        icon = "user"
-        form_classname = "whatsapp-message-block struct-block"
 
 
 class ViberBlock(blocks.StructBlock):
@@ -339,6 +336,29 @@ class ContentPage(Page, ContentImportMixin):
     @property
     def whatsapp_template_body(self):
         return self.whatsapp_body.raw_data[0]["value"]["message"]
+
+    def clean(self):
+        message_with_media_length = 1024
+        errors = []
+        for message in self.whatsapp_body:
+            if (
+                (
+                    "image" in message.value
+                    and "document" in message.value
+                    and "media" in message.value
+                )
+                and (
+                    message.value["image"]
+                    or message.value["document"]
+                    or message.value["media"]
+                )
+                and len(message.value["message"]) > message_with_media_length
+            ):
+                errors.append(
+                    f"A WhatsApp message with media cannot be longer than {message_with_media_length} characters long, your message is {len(message.value['message'])} characters long"
+                )
+        if errors:
+            raise ValidationError(errors)
 
     def get_descendants(self, inclusive=False):
         return ContentPage.objects.descendant_of(self, inclusive)

--- a/home/tests/utils.py
+++ b/home/tests/utils.py
@@ -1,16 +1,28 @@
 from taggit.models import Tag
 from wagtail import blocks
+from wagtail.documents.blocks import DocumentChooserBlock
+from wagtail.images.blocks import ImageChooserBlock
 
-from home.models import ContentPage, ContentPageRating, HomePage
+from home.models import ContentPage, ContentPageRating, HomePage, MediaBlock
 
 
 def create_page(title="Test Title", parent=None, tags=[], is_whatsapp_template=False):
     block = blocks.StructBlock(
         [
             ("message", blocks.TextBlock()),
+            ("image", ImageChooserBlock()),
+            ("media", MediaBlock()),
+            ("document", DocumentChooserBlock()),
         ]
     )
-    block_value = block.to_python({"message": "Test WhatsApp Message 1"})
+    block_value = block.to_python(
+        {
+            "message": "Test WhatsApp Message 1",
+            "image": None,
+            "media": None,
+            "document": None,
+        }
+    )
     contentpage = ContentPage(
         title=title,
         subtitle="Test Subtitle",


### PR DESCRIPTION
Adding a validation to contentpage to ensure whatsapp message with attachment is shorter than 1024 chars

A `clean` method on the `ContentPage` object validates the whatsapp block to ensure that a message with an image, document or media cannot exceed 1024 characters (tested and python counts emoji's as 1 character)

An error banner is raised at the top with a list of errors - I was unable to get the errors onto a block level

![whatsapp message validation failed](https://user-images.githubusercontent.com/61986385/191723280-a1e74a77-47de-4fd9-85e0-bb24e19cbd6d.PNG)
