### PR TITLE
Add extra data sort to ensure that data is in date order

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -108,6 +108,7 @@ class PageViewReportView(ReportView):
             .annotate(x=F("month"), y=Count("page_id"))
             .values("x", "y")
         )
+        view_per_month.sort(key=lambda item: item["x"])
         labels = [item["x"].date() for item in view_per_month]
         return {"data": view_per_month, "labels": labels}
 


### PR DESCRIPTION
PageViews graph are not always correctly ordered. I tried but failed to replicate this locally, but I added a sort to the data to sort it by the date after the data is retrieved.


![bug 1](https://user-images.githubusercontent.com/61986385/192763849-593159f6-bae6-4c38-9247-4c2edd96e517.PNG)
