### PR TITLE
hacky fix for encoding issues in the import due to xlsx format

### DIFF
--- a/home/utils.py
+++ b/home/utils.py
@@ -257,7 +257,9 @@ def import_content(file, filetype, purge=True, locale="en"):
         for row in ws.iter_rows():
             row_dict = {}
             for index, x in enumerate(row):
-                row_dict[EXPORT_FIELDNAMES[index]] = x.value
+                row_dict[EXPORT_FIELDNAMES[index]] = (
+                    x.value.replace("_x000D_", "") if x.value else None
+                )
             lines.append(row_dict)
     else:
         if isinstance(file, bytes):


### PR DESCRIPTION
It appears that excel is replacing the line separator used by unix based systems (`\n`) with the  line separator used by windows based systems (`\r\n`) but it decodes as `_x000D_` plus a line separator, a similar issue can be found [here](https://stackoverflow.com/questions/71574319/how-to-remove-newline-characters-so-it-doesnt-produce-x000d-when-reading-exce). 

I think this needs a better solution but I have been playing around with the file for a bit but I can't seem to get anything better than this 