### PR TITLE
submit quickreplies as template buttons

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -520,8 +520,8 @@ class ContentPage(Page, ContentImportMixin):
         if settings.WHATSAPP_CREATE_TEMPLATES and self.is_whatsapp_template:
             quick_reply_buttons = []
             if self.quick_reply_items.count() > 0:
-                quick_reply_buttons = self.quick_reply_items.all().values_list(
-                    "tag__name", flat=True
+                quick_reply_buttons = list(
+                    self.quick_reply_items.all().values_list("tag__name", flat=True)
                 )
             create_whatsapp_template(
                 self.whatsapp_template_name,

--- a/home/models.py
+++ b/home/models.py
@@ -518,8 +518,15 @@ class ContentPage(Page, ContentImportMixin):
             clean,
         )
         if settings.WHATSAPP_CREATE_TEMPLATES and self.is_whatsapp_template:
+            quick_reply_buttons = []
+            if self.quick_reply_items.count() > 0:
+                quick_reply_buttons = self.quick_reply_items.all().values_list(
+                    "tag__name", flat=True
+                )
             create_whatsapp_template(
-                self.whatsapp_template_name, self.whatsapp_template_body
+                self.whatsapp_template_name,
+                self.whatsapp_template_body,
+                quick_reply_buttons,
             )
         return response
 

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -51,3 +51,13 @@ class ContentPageTests(TestCase):
         mock_create_whatsapp_template.assert_called_with(
             f"WA_Title_{page.get_latest_revision().id}", "Test WhatsApp Message 1", []
         )
+
+    @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
+    @mock.patch("home.models.create_whatsapp_template")
+    def test_template_create_with_buttons_on_save(self, mock_create_whatsapp_template):
+        page = create_page(is_whatsapp_template=True, has_quick_replies=True)
+        mock_create_whatsapp_template.assert_called_with(
+            f"WA_Title_{page.get_latest_revision().id}",
+            "Test WhatsApp Message 1",
+            ["tag 1", "tag 2"],
+        )

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -59,5 +59,5 @@ class ContentPageTests(TestCase):
         mock_create_whatsapp_template.assert_called_with(
             f"WA_Title_{page.get_latest_revision().id}",
             "Test WhatsApp Message 1",
-            ["tag 1", "tag 2"],
+            ["button 1", "button 2"],
         )

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -49,5 +49,5 @@ class ContentPageTests(TestCase):
     def test_template_create_on_save(self, mock_create_whatsapp_template):
         page = create_page(is_whatsapp_template=True)
         mock_create_whatsapp_template.assert_called_with(
-            f"WA_Title_{page.get_latest_revision().id}", "Test WhatsApp Message 1"
+            f"WA_Title_{page.get_latest_revision().id}", "Test WhatsApp Message 1", []
         )

--- a/home/tests/test_whatsapp.py
+++ b/home/tests/test_whatsapp.py
@@ -24,3 +24,32 @@ class WhatsAppTests(TestCase):
 
         self.assertEquals(request.headers["Authorization"], "Bearer fake-access-token")
         self.assertEquals(request.body, json.dumps(data, indent=4))
+
+    @responses.activate
+    def test_create_whatsapp_template_with_buttons(self):
+        data = {
+            "category": "ACCOUNT_UPDATE",
+            "name": "test-template",
+            "language": "en_US",
+            "components": [
+                {"type": "BODY", "text": "Test Body"},
+                {
+                    "type": "BUTTONS",
+                    "buttons": [
+                        {"type": "QUICK_REPLY", "text": "Test button1"},
+                        {"type": "QUICK_REPLY", "text": "test button2"},
+                    ],
+                },
+            ],
+        }
+        url = "http://whatsapp/graph/v3.3/27121231234/message_templates"
+        responses.add(responses.POST, url, json={})
+
+        create_whatsapp_template(
+            "Test-Template", "Test Body", ["Test button1", "test button2"]
+        )
+
+        request = responses.calls[0].request
+
+        self.assertEquals(request.headers["Authorization"], "Bearer fake-access-token")
+        self.assertEquals(request.body, json.dumps(data, indent=4))

--- a/home/tests/test_whatsapp.py
+++ b/home/tests/test_whatsapp.py
@@ -18,7 +18,7 @@ class WhatsAppTests(TestCase):
         url = "http://whatsapp/graph/v3.3/27121231234/message_templates"
         responses.add(responses.POST, url, json={})
 
-        create_whatsapp_template("test-template", "Test Body")
+        create_whatsapp_template("Test-Template", "Test Body")
 
         request = responses.calls[0].request
 

--- a/home/tests/utils.py
+++ b/home/tests/utils.py
@@ -9,7 +9,6 @@ from home.models import (  # isort:skip
     ContentQuickReply,
     HomePage,
     MediaBlock,
-    QuickReplyContent,
     VariationBlock,
 )
 
@@ -48,10 +47,6 @@ def create_page(
             "variation_messages": variation_messages,
         }
     )
-    # Option 1
-    # quick_replies = []
-    # if has_quick_replies:
-    #     quick_replies = ["tag 1", "tag 2"]
 
     contentpage = ContentPage(
         title=title,
@@ -60,14 +55,13 @@ def create_page(
         whatsapp_title="WA Title",
         whatsapp_body=[("Whatsapp_Message", block_value)],
         is_whatsapp_template=is_whatsapp_template,
-        # quick_replies = quick_replies, #Option 1 continued
     )
-    # Option 2
-    # if has_quick_replies:
-    #     tag1 = ContentQuickReply(name="tag 1")
-    #     tag2 = ContentQuickReply(name="tag 2")
-    #     QuickReplyContent(tag=tag1, content_object=contentpage)
-    #     QuickReplyContent(tag=tag2, content_object=contentpage)
+
+    if has_quick_replies:
+        created_qr, _ = ContentQuickReply.objects.get_or_create(name="button 1")
+        contentpage.quick_replies.add(created_qr)
+        created_qr, _ = ContentQuickReply.objects.get_or_create(name="button 2")
+        contentpage.quick_replies.add(created_qr)
     for tag in tags:
         created_tag, _ = Tag.objects.get_or_create(name=tag)
         contentpage.tags.add(created_tag)

--- a/home/tests/utils.py
+++ b/home/tests/utils.py
@@ -6,8 +6,10 @@ from wagtail.images.blocks import ImageChooserBlock
 from home.models import (  # isort:skip
     ContentPage,
     ContentPageRating,
+    ContentQuickReply,
     HomePage,
     MediaBlock,
+    QuickReplyContent,
     VariationBlock,
 )
 
@@ -18,6 +20,7 @@ def create_page(
     tags=[],
     is_whatsapp_template=False,
     add_variation=False,
+    has_quick_replies=False,
 ):
     block = blocks.StructBlock(
         [
@@ -45,6 +48,11 @@ def create_page(
             "variation_messages": variation_messages,
         }
     )
+    # Option 1
+    # quick_replies = []
+    # if has_quick_replies:
+    #     quick_replies = ["tag 1", "tag 2"]
+
     contentpage = ContentPage(
         title=title,
         subtitle="Test Subtitle",
@@ -52,7 +60,14 @@ def create_page(
         whatsapp_title="WA Title",
         whatsapp_body=[("Whatsapp_Message", block_value)],
         is_whatsapp_template=is_whatsapp_template,
+        # quick_replies = quick_replies, #Option 1 continued
     )
+    # Option 2
+    # if has_quick_replies:
+    #     tag1 = ContentQuickReply(name="tag 1")
+    #     tag2 = ContentQuickReply(name="tag 2")
+    #     QuickReplyContent(tag=tag1, content_object=contentpage)
+    #     QuickReplyContent(tag=tag2, content_object=contentpage)
     for tag in tags:
         created_tag, _ = Tag.objects.get_or_create(name=tag)
         contentpage.tags.add(created_tag)

--- a/home/whatsapp.py
+++ b/home/whatsapp.py
@@ -5,7 +5,7 @@ import requests
 from django.conf import settings
 
 
-def create_whatsapp_template(name, body):
+def create_whatsapp_template(name, body, quick_replies=[]):
     url = urljoin(
         settings.WHATSAPP_API_URL,
         f"graph/v3.3/{settings.FB_BUSINESS_ID}/message_templates",
@@ -14,11 +14,19 @@ def create_whatsapp_template(name, body):
         "Authorization": "Bearer {}".format(settings.WHATSAPP_ACCESS_TOKEN),
         "Content-Type": "application/json",
     }
+
+    components = [{"type": "BODY", "text": body}]
+    if quick_replies:
+        buttons = []
+        for button in quick_replies:
+            buttons.append({"type": "QUICK_REPLY", "text": button})
+        components.append({"type": "BUTTONS", "buttons": buttons})
+
     data = {
         "category": "ACCOUNT_UPDATE",
         "name": name.lower(),
         "language": "en_US",
-        "components": [{"type": "BODY", "text": body}],
+        "components": components,
     }
 
     response = requests.post(

--- a/home/whatsapp.py
+++ b/home/whatsapp.py
@@ -16,7 +16,7 @@ def create_whatsapp_template(name, body):
     }
     data = {
         "category": "ACCOUNT_UPDATE",
-        "name": name,
+        "name": name.lower(),
         "language": "en_US",
         "components": [{"type": "BODY", "text": body}],
     }


### PR DESCRIPTION
## Purpose
We need to be able to create WhatsApp templates with buttons

Also, submit the template with a lowercase name, since template names cannot contain capital letters.

## Approach
Pull the button text from the existing QuickReplies field.

## Outstanding
I'm struggling to create a page with QuickReplies in order to test the model save. Two options for how to create this page are in the tests/utils.py file but I haven't been able to get either to work. Neither option throws any errors, they just both result in the `quick_reply_items` field being empty
