### PR TITLE
Display ordered set details on list endpoint

### DIFF
--- a/home/api.py
+++ b/home/api.py
@@ -67,11 +67,10 @@ class ContentPageIndexViewSet(PagesAPIViewSet):
 class OrderedContentSetViewSet(BaseAPIViewSet):
     model = OrderedContentSet
     base_serializer_class = OrderedContentSetSerializer
-    known_query_parameters = set(
-        [
-            "name",
-        ]
-    )
+    listing_default_fields = BaseAPIViewSet.listing_default_fields + [
+        "name",
+        "profile_fields",
+    ]
     pagination_class = PageNumberPagination
 
     @method_decorator(cache_page(60 * 60 * 2))

--- a/home/api.py
+++ b/home/api.py
@@ -1,5 +1,6 @@
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
+from rest_framework.filters import SearchFilter
 from rest_framework.pagination import PageNumberPagination
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.api.v2.views import BaseAPIViewSet, PagesAPIViewSet
@@ -72,6 +73,8 @@ class OrderedContentSetViewSet(BaseAPIViewSet):
         "profile_fields",
     ]
     pagination_class = PageNumberPagination
+    search_fields = ["name", "profile_fields"]
+    filter_backends = (SearchFilter,)
 
     @method_decorator(cache_page(60 * 60 * 2))
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
## Purpose
The list endpoint was only showing the detail url and the id. We needed the name and the profile fields too.
We also needed to be able to search or filter the list of ordered sets

I wanted to make a more sophisticated filter for the profile fields but [this SO answer](https://stackoverflow.com/a/44442341) from one of the Wagtail devs indicated that I wasn't going to have a good time of that
