### PR TITLE
Filter pageviews by json data field

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -206,6 +206,14 @@ class PageViewViewSet(GenericListViewset):
     serializer_class = PageViewSerializer
     filterset_class = PageViewFilter
 
+    def get_queryset(self):
+        # filter the queryset by data jsonfield:
+        queryset = self.queryset
+        for key, value in self.request.GET.items():
+            if "data__" in key:
+                queryset = queryset.filter(**{key: value})
+        return queryset
+
 
 class ContentPageRatingViewSet(GenericListViewset, CreateModelMixin):
     queryset = ContentPageRating.objects.all()

--- a/home/views.py
+++ b/home/views.py
@@ -213,11 +213,11 @@ class PageViewViewSet(GenericListViewset):
         for key, value in self.request.GET.items():
             if "data__" in key:
                 queryset = queryset.filter(**{key: value})
-        
+
         # Only return unique pages
         if self.request.GET.get("unique_pages", False) == "true":
             if db_connection.vendor == "postgresql":
-                queryset = queryset.distinct('page')
+                queryset = queryset.distinct("page")
             else:
                 raise ValidationError({"unique_pages": ["This query is not supported"]})
 

--- a/home/views.py
+++ b/home/views.py
@@ -2,6 +2,7 @@ import json
 import threading
 
 import django_filters
+from django.db import connection as db_connection
 from django.db.models import Count, F
 from django.db.models.functions import TruncMonth
 from django.forms import MultiWidget
@@ -212,6 +213,14 @@ class PageViewViewSet(GenericListViewset):
         for key, value in self.request.GET.items():
             if "data__" in key:
                 queryset = queryset.filter(**{key: value})
+        
+        # Only return unique pages
+        if self.request.GET.get("unique_pages", False) == "true":
+            if db_connection.vendor == "postgresql":
+                queryset = queryset.distinct('page')
+            else:
+                raise ValidationError({"unique_pages": ["This query is not supported"]})
+
         return queryset
 
 


### PR DESCRIPTION
## Purpose
Allow the PageViews API endpoint to be filtered by values in the data. This allows us to query for which pages a user has seen