### PR TITLE
Feature/fix filtering pageviews by distinct

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -217,6 +217,8 @@ class PageViewViewSet(GenericListViewset):
         # Only return unique pages
         if self.request.GET.get("unique_pages", False) == "true":
             if db_connection.vendor == "postgresql":
+                # Fields used for "distinct" must be the first thing we order by
+                self.pagination_class.ordering="page"
                 queryset = queryset.distinct("page")
             else:
                 raise ValidationError({"unique_pages": ["This query is not supported"]})

--- a/home/views.py
+++ b/home/views.py
@@ -217,8 +217,8 @@ class PageViewViewSet(GenericListViewset):
         # Only return unique pages
         if self.request.GET.get("unique_pages", False) == "true":
             if db_connection.vendor == "postgresql":
-                # Fields used for "distinct" must be the first thing we order by
-                self.pagination_class.ordering="page"
+                # Fields used for "distinct" must be used for ordering
+                self.paginator.ordering = "page"
                 queryset = queryset.distinct("page")
             else:
                 raise ValidationError({"unique_pages": ["This query is not supported"]})


### PR DESCRIPTION
## Purpose
In order to use `distinct()` with a field argument we have to ensure that the query is first ordered by the same field we are using for the "distinct" query
In the PageViewViewSet the query is being ordered by an attribute on the Pagination class. So this needs to be changed for this request.

For more info see the Django docs for Distinct https://docs.djangoproject.com/en/1.10/ref/models/querysets/#distinct
