### PR TITLE
Add management command for migrating related tags

### DIFF
--- a/home/management/commands/change_related_tag_to_related_page.py
+++ b/home/management/commands/change_related_tag_to_related_page.py
@@ -1,0 +1,47 @@
+import json
+
+from django.core.management.base import BaseCommand
+
+from home.models import ContentPage
+
+
+class Command(BaseCommand):
+    help = (
+        "Takes all 'related_<id>' tags, and adds them as related pages. Does not "
+        "remove any tags. Only acts on live pages. If all the related pages specified "
+        "by tags are already there, then no action is taken. Publishes a new revision "
+        "with related pages added."
+    )
+    TAG_PREFIX = "related_"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--no-dry-run",
+            action="store_true",
+            help="By default we do a dry run. Use this to actually execute the command",
+        )
+
+    def handle(self, *args, **options):
+        pages = ContentPage.objects.live().filter(
+            tags__name__startswith=self.TAG_PREFIX
+        )
+        for page in pages:
+            related_pages = set(p.value.id for p in page.related_pages)
+            existing_related_pages = related_pages.copy()
+            for tag in page.tags.filter(name__startswith=self.TAG_PREFIX):
+                page_id = int(tag.name.replace(self.TAG_PREFIX, ""))
+                related_pages.add(page_id)
+            if related_pages == existing_related_pages:
+                continue
+            if options["no_dry_run"]:
+                page.related_pages = json.dumps(
+                    [{"type": "related_page", "value": id} for id in related_pages]
+                )
+                page.save_revision().publish()
+            self.stdout.write(f"Added related pages {related_pages} to {page}")
+
+        if not options["no_dry_run"]:
+            self.stdout.write(
+                "WARNING: Dry run mode, not making any changes. Use --no-dry-run to "
+                "make database changes"
+            )

--- a/home/tests/test_management_related_tag.py
+++ b/home/tests/test_management_related_tag.py
@@ -1,0 +1,72 @@
+import json
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+from taggit.models import Tag
+
+from home.models import ContentPage, HomePage
+
+
+class ManagementRelatedTag(TestCase):
+    def setUp(self):
+        """
+        Create a page with no tags or related pages, the `related_page`
+        Create a page with a tag pointing to `related_page`, no related pages
+        """
+        home_page = HomePage.objects.first()
+        self.related_page = ContentPage(title="Related page", slug="related-page")
+        home_page.add_child(instance=self.related_page)
+        self.page = ContentPage(title="Test page", slug="test-page")
+        self.page.tags.add(Tag.objects.create(name=f"related_{self.related_page.id}"))
+        home_page.add_child(instance=self.page)
+
+    def test_default_dry_run(self):
+        """
+        Dry run should happen by default, it should log the changes but not make any.
+        """
+        out = StringIO()
+
+        call_command("change_related_tag_to_related_page", stdout=out)
+
+        self.assertIn(
+            f"Added related pages {{{self.related_page.id}}} to {self.page}",
+            out.getvalue(),
+        )
+        self.page.refresh_from_db()
+        self.assertEqual(len(self.page.related_pages), 0)
+        self.assertIn("Dry run", out.getvalue())
+
+    def test_no_dry_run(self):
+        """
+        With the --no-dry-run flag, the changes should be comitted to the database.
+        Related pages should be added, but no tags should be removed
+        """
+        out = StringIO()
+
+        call_command("change_related_tag_to_related_page", "--no-dry-run", stdout=out)
+
+        self.assertIn(
+            f"Added related pages {{{self.related_page.id}}} to {self.page}",
+            out.getvalue(),
+        )
+        self.page.refresh_from_db()
+        self.assertEqual(len(self.page.related_pages), 1)
+        self.assertNotIn("Dry run", out.getvalue())
+
+    def test_existing_related_pages(self):
+        """
+        If for all the tags, the related pages are there already, then no action should
+        be taken
+        """
+        out = StringIO()
+        self.page.related_pages = json.dumps(
+            [{"type": "related_page", "value": self.related_page.id}]
+        )
+        self.page.save_revision().publish()
+
+        call_command("change_related_tag_to_related_page", "--no-dry-run", stdout=out)
+
+        self.assertEqual(out.getvalue(), "")
+        page = ContentPage.objects.get(id=self.page.id)
+        self.assertEqual(page, self.page)


### PR DESCRIPTION
## Purpose
Related tags are considered depricated, and we want to use related pages instead.

## Approach
This adds a management command to set the related pages from the related tags, for any content that is not yet using the related pages.
