### PR TITLE
Hotfix restrict import access

### DIFF
--- a/contentrepo/static/js/contentrepo.js
+++ b/contentrepo/static/js/contentrepo.js
@@ -12,11 +12,11 @@ $(".meter > span").each(function () {
 
 function getUploadState(){
  $.ajax({
-  url: '/import/',
+  url: importURL,
   type: 'get',
   success: function(response){
    if(response != "True"){
-    window.location.href = '/admin/home/contentpage/';
+    window.location.href = destinationURL;
    }
   }
  });

--- a/contentrepo/templates/upload.html
+++ b/contentrepo/templates/upload.html
@@ -29,7 +29,7 @@
             <span id="loadingBar" style="width: 50%"><span></span></span>
         </div>
     {% else %}
-      <form action="/import/" method="POST" enctype="multipart/form-data">
+      <form action="/admin/import/" method="POST" enctype="multipart/form-data">
           {% csrf_token %}
           <ul class="fields">
               <li class="required {{ wrapper_classes }} {{ li_classes }} {% if field.errors %}error{% endif %}">

--- a/contentrepo/templates/upload.html
+++ b/contentrepo/templates/upload.html
@@ -29,7 +29,7 @@
             <span id="loadingBar" style="width: 50%"><span></span></span>
         </div>
     {% else %}
-      <form action="/admin/import/" method="POST" enctype="multipart/form-data">
+      <form action="{% url 'import' %}" method="POST" enctype="multipart/form-data">
           {% csrf_token %}
           <ul class="fields">
               <li class="required {{ wrapper_classes }} {{ li_classes }} {% if field.errors %}error{% endif %}">
@@ -53,5 +53,9 @@
 {% endblock %}
 
 {% block extra_js %}
+    <script>
+      var importURL = "{% url 'import' %}";
+      var destinationURL = "{% url 'home_contentpage_modeladmin_index' %}";
+    </script>
     <script type="text/javascript" src="{% static 'js/contentrepo.js' %}"></script>
 {% endblock %}

--- a/contentrepo/urls.py
+++ b/contentrepo/urls.py
@@ -32,7 +32,6 @@ urlpatterns = [
     path("search/", search_views.search, name="search"),
     path("mainmenu/", menu_views.mainmenu, name="mainmenu"),
     path("submenu/", menu_views.submenu, name="submenu"),
-    path("import/", home_views.UploadView.as_view(), name="import"),
     path("randommenu/", menu_views.randommenu, name="randommenu"),
     path("faqmenu/", menu_views.faqmenu, name="faqmenu"),
     path("suggestedcontent/", menu_views.suggestedcontent, name="suggestedcontent"),

--- a/home/templates/modeladmin/index.html
+++ b/home/templates/modeladmin/index.html
@@ -19,7 +19,7 @@
             </div>
             <div class="actionbutton">
                     <div class="dropdown dropdown-button match-width col">
-                        <a href="/import/" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Import' %}</a>
+                        <a href="/admin/import/" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Import' %}</a>
                     </div>
             </div>
 

--- a/home/templates/modeladmin/index.html
+++ b/home/templates/modeladmin/index.html
@@ -19,7 +19,7 @@
             </div>
             <div class="actionbutton">
                     <div class="dropdown dropdown-button match-width col">
-                        <a href="/admin/import/" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Import' %}</a>
+                        <a href="{% url 'import' %}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Import' %}</a>
                     </div>
             </div>
 

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -5,13 +5,19 @@ from wagtail.admin.menu import AdminOnlyMenuItem
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 
 from .models import ContentPage
-from .views import ContentPageReportView, CustomIndexView, PageViewReportView, UploadView
+
+from .views import (  # isort:skip
+    ContentPageReportView,
+    CustomIndexView,
+    PageViewReportView,
+    UploadView,
+)
 
 
-@hooks.register('register_admin_urls')
+@hooks.register("register_admin_urls")
 def register_import_urls():
     return [
-        path('import/', UploadView.as_view(), name='import'),
+        path("import/", UploadView.as_view(), name="import"),
     ]
 
 

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -5,7 +5,14 @@ from wagtail.admin.menu import AdminOnlyMenuItem
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 
 from .models import ContentPage
-from .views import ContentPageReportView, CustomIndexView, PageViewReportView
+from .views import ContentPageReportView, CustomIndexView, PageViewReportView, UploadView
+
+
+@hooks.register('register_admin_urls')
+def register_calendar_url():
+    return [
+        path('import/', UploadView.as_view(), name='import'),
+    ]
 
 
 @hooks.register("register_page_listing_buttons")

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -9,7 +9,7 @@ from .views import ContentPageReportView, CustomIndexView, PageViewReportView, U
 
 
 @hooks.register('register_admin_urls')
-def register_calendar_url():
+def register_import_urls():
     return [
         path('import/', UploadView.as_view(), name='import'),
     ]
@@ -18,7 +18,7 @@ def register_calendar_url():
 @hooks.register("register_page_listing_buttons")
 def page_listing_buttons(page, page_perms, is_parent=False, next_url=None):
     yield wagtailadmin_widgets.PageListingButton(
-        "Import Content", "/import/", priority=10
+        "Import Content", reverse("import"), priority=10
     )
 
 


### PR DESCRIPTION
## Purpose
The /import path is accessible without admin permissions. It should be locked behind the admin login.
(Tx @rudigiesler for the js and template changes I missed)

## Approach
Register the url as an admin url.

## Learning
Followed these docs https://docs.wagtail.org/en/latest/extending/admin_views.html