### PR TITLE
Handle invalid IDs on related tags

### DIFF
--- a/home/management/commands/change_related_tag_to_related_page.py
+++ b/home/management/commands/change_related_tag_to_related_page.py
@@ -1,6 +1,7 @@
 import json
 
 from django.core.management.base import BaseCommand
+from wagtail.models import Page
 
 from home.models import ContentPage
 
@@ -22,15 +23,23 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        pages = ContentPage.objects.live().filter(
-            tags__name__startswith=self.TAG_PREFIX
+        pages = (
+            ContentPage.objects.live()
+            .filter(tags__name__startswith=self.TAG_PREFIX)
+            .distinct()
         )
         for page in pages:
-            related_pages = set(p.value.id for p in page.related_pages)
+            related_pages = set(p.value and p.value.id for p in page.related_pages)
             existing_related_pages = related_pages.copy()
+            # Add any related pages specified by tags
             for tag in page.tags.filter(name__startswith=self.TAG_PREFIX):
                 page_id = int(tag.name.replace(self.TAG_PREFIX, ""))
                 related_pages.add(page_id)
+            # Remove any non-existing related pages
+            related_pages = set(
+                Page.objects.filter(id__in=related_pages).values_list("id", flat=True)
+            )
+
             if related_pages == existing_related_pages:
                 continue
             if options["no_dry_run"]:

--- a/home/management/commands/change_related_tag_to_related_page.py
+++ b/home/management/commands/change_related_tag_to_related_page.py
@@ -29,7 +29,9 @@ class Command(BaseCommand):
             .distinct()
         )
         for page in pages:
-            related_pages = set(p.value and p.value.id for p in page.related_pages)
+            related_pages = set(
+                p.value.id if p.value else None for p in page.related_pages
+            )
             existing_related_pages = related_pages.copy()
             # Add any related pages specified by tags
             for tag in page.tags.filter(name__startswith=self.TAG_PREFIX):


### PR DESCRIPTION
## Purpose
Previously, the management command trusted that the IDs in the related tags existed, but this is not the case if there are some broken tags.

This leaves the related pages in a broken state, so we rather make sure that the ID in the tag exists, before adding it to the related pages.

## Approach
Before setting the related pages, we filter the IDs by whether a page in the database exists for that ID.
