### PR TITLE
Increase gunicorn worker timout in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ USER wagtail
 
 ENV DJANGO_SETTINGS_MODULE=contentrepo.settings.production
 
-CMD set -xe; gunicorn contentrepo.wsgi:application
+CMD set -xe; gunicorn contentrepo.wsgi:application --timeout 120

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ USER wagtail
 
 ENV DJANGO_SETTINGS_MODULE=contentrepo.settings.production
 
-CMD set -xe; gunicorn contentrepo.wsgi:application --timeout 120
+CMD set -xe; gunicorn  --timeout 120 contentrepo.wsgi:application


### PR DESCRIPTION
## Purpose
Large content imports are timing out before the file is loaded. I'm hoping this will resolve that.
The default is 30s
