### PR TITLE
Send related pages and tags with ordered set details

### DIFF
--- a/home/serializers.py
+++ b/home/serializers.py
@@ -288,12 +288,16 @@ class PagesField(serializers.Field):
             elif "viber" in request.GET and page.enable_viber is True:
                 if page.viber_title:
                     title = page.viber_title
-            pages.append(
-                {
-                    "id": page.id,
-                    "title": title,
-                }
-            )
+            page_data = {
+                "id": page.id,
+                "title": title,
+            }
+            if "show_related" in request.GET and bool(request.GET["show_related"]):
+                page_data["related_pages"] = [p.value.id for p in page.related_pages]
+            if "show_tags" in request.GET and bool(request.GET["show_tags"]):
+                page_data["tags"] = [x.name for x in page.tags.all()]
+
+            pages.append(page_data)
         return pages
 
 

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -4,11 +4,16 @@ from pathlib import Path
 from django.test import Client, TestCase
 from wagtail import blocks
 
-from home.models import (ContentPage, OrderedContentSet, PageView,
-                         VariationBlock)
 from home.utils import import_content
 
 from .utils import create_page
+
+from home.models import (  # isort:skip
+    ContentPage,
+    OrderedContentSet,
+    PageView,
+    VariationBlock,
+)
 
 
 class PaginationTestCase(TestCase):

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -163,7 +163,7 @@ class OrderedContentSetAdmin(ModelAdmin):
     menu_order = 200
     add_to_settings_menu = False
     exclude_from_explorer = False
-    list_display = ("name", "profile_fields")
+    list_display = ("name", "profile_fields", "num_pages")
     list_export = ("name", "profile_field", "page")
     search_fields = ("name", "profile_fields")
 
@@ -178,6 +178,11 @@ class OrderedContentSetAdmin(ModelAdmin):
         return ["-"]
 
     page.short_description = "Page Slugs"
+
+    def num_pages(self, obj):
+        return len(obj.pages)
+
+    num_pages.short_description = "Number of Pages"
 
 
 # Now you just need to register your customised ModelAdmin class with Wagtail


### PR DESCRIPTION
## Purpose
Due to various limitations in RapidPro we need to reduce the number of http calls used when trying to determine what page to show a user.

## Approach
Adds flags to the ordered set api endpoint to return details for the linked pages.
