### PR TITLE
Handle slugs that don't exist when importing related pages

### DIFF
--- a/home/utils.py
+++ b/home/utils.py
@@ -439,11 +439,15 @@ def import_content(file, filetype, purge=True, locale="en"):
                 related_page = ContentPage.objects.filter(
                     slug=related_page_slug
                 ).first()
-                related_pages_raw_data.append(
-                    {"type": "related_page", "value": related_page.id}
-                )
-            page.related_pages = dumps(related_pages_raw_data)
-            page.save_revision().publish()
+                if related_page:
+                    related_pages_raw_data.append(
+                        {"type": "related_page", "value": related_page.id}
+                    )
+                else:
+                    print(f"Content page not found for slug '{related_page_slug}'")
+            if related_pages_raw_data:
+                page.related_pages = dumps(related_pages_raw_data)
+                page.save_revision().publish()
 
 
 def style_sheet(wb: Workbook, sheet: Worksheet) -> Tuple[Workbook, Worksheet]:


### PR DESCRIPTION
## Purpose
We get an error if there is a slug for a page that doesn't exist after the import

## Approach
This logs the issue and the slug name and continues with the import

