### PR TITLE
Fix setting is_whatsapp_template should submit template

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -522,6 +522,7 @@ class ContentPage(Page, ContentImportMixin):
                 self.whatsapp_template_body == previous_revision.whatsapp_template_body
                 and sorted(self.quick_reply_buttons)
                 == sorted(previous_revision.quick_reply_buttons)
+                and self.is_whatsapp_template == previous_revision.is_whatsapp_template
             ):
                 return
         except AttributeError:


### PR DESCRIPTION

## Purpose
If a message wasn't set as a template, but then a new revision comes in that sets it as a template, it should be submitted, even though the content hasn't changed.


## Approach
When we check if the body and buttons are the same, we should also check if the value of is_whatsapp_template is the same, so that if it changes from False to True, then we also submit a template
