### PR TITLE
Update WhatsApp Template category to UTILITY

### DIFF
--- a/home/tests/test_whatsapp.py
+++ b/home/tests/test_whatsapp.py
@@ -10,7 +10,7 @@ class WhatsAppTests(TestCase):
     @responses.activate
     def test_create_whatsapp_template(self):
         data = {
-            "category": "ACCOUNT_UPDATE",
+            "category": "UTILITY",
             "name": "test-template",
             "language": "en_US",
             "components": [{"type": "BODY", "text": "Test Body"}],
@@ -28,7 +28,7 @@ class WhatsAppTests(TestCase):
     @responses.activate
     def test_create_whatsapp_template_with_buttons(self):
         data = {
-            "category": "ACCOUNT_UPDATE",
+            "category": "UTILITY",
             "name": "test-template",
             "language": "en_US",
             "components": [

--- a/home/whatsapp.py
+++ b/home/whatsapp.py
@@ -23,7 +23,7 @@ def create_whatsapp_template(name, body, quick_replies=[]):
         components.append({"type": "BUTTONS", "buttons": buttons})
 
     data = {
-        "category": "ACCOUNT_UPDATE",
+        "category": "UTILITY",
         "name": name.lower(),
         "language": "en_US",
         "components": components,


### PR DESCRIPTION
Whatsapp changed their template category names, so updating the one we use by default from ACCOUNT_UPDATE to UTILITY
