### PR TITLE
Truncate message bodies on ContentPage admin list view

### DIFF
--- a/home/tests/test_wagtail_hooks.py
+++ b/home/tests/test_wagtail_hooks.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+
+from home.wagtail_hooks import ContentPageAdmin
+from home.models import ContentPage
+
+class ContentPageAdminTests(TestCase):
+    def test_body_text_truncation(self):
+        """
+        Body text for web, whatsapp, messenger, and viber, should be truncated in this
+        list view
+        """
+        page = ContentPage(
+            body=[("paragraph", "test " * 100)],
+        )
+        page.whatsapp_body.append(("Whatsapp_Message", {"message": "test " * 100}))
+        page.messenger_body.append(("messenger_block", {"message": "test " * 100}))
+        page.viber_body.append(("viber_message", {"message": "test " * 100}))
+        admin = ContentPageAdmin()
+
+        self.assertEqual(len(admin.web_body(page)), 200)
+        self.assertEqual(len(admin.wa_body(page)), 200)
+        self.assertEqual(len(admin.mess_body(page)), 200)
+        self.assertEqual(len(admin.vib_body(page)), 200)
+        # Web body is different to the rest because of the html
+        self.assertEqual(admin.web_body(page)[-6:], "test …")
+        self.assertEqual(admin.wa_body(page)[-5:], "test…")
+        self.assertEqual(admin.mess_body(page)[-5:], "test…")
+        self.assertEqual(admin.vib_body(page)[-5:], "test…")

--- a/home/tests/test_wagtail_hooks.py
+++ b/home/tests/test_wagtail_hooks.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
 
-from home.wagtail_hooks import ContentPageAdmin
 from home.models import ContentPage
+from home.wagtail_hooks import ContentPageAdmin
+
 
 class ContentPageAdminTests(TestCase):
     def test_body_text_truncation(self):

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -1,3 +1,4 @@
+from django.template.defaultfilters import truncatechars
 from django.urls import path, reverse
 from wagtail import hooks
 from wagtail.admin import widgets as wagtailadmin_widgets
@@ -78,6 +79,7 @@ def register_page_views_report_url():
 
 
 class ContentPageAdmin(ModelAdmin):
+    body_truncate_size = 200
     model = ContentPage
     menu_label = "ContentPages"
     menu_icon = "pilcrow"
@@ -126,28 +128,25 @@ class ContentPageAdmin(ModelAdmin):
     tag.short_description = "Tags"
 
     def wa_body(self, obj):
-        return [m.value["message"] for m in obj.whatsapp_body]
+        body = "\n".join(m.value["message"] for m in obj.whatsapp_body)
+        return truncatechars(str(body), self.body_truncate_size)
 
     wa_body.short_description = "Whatsapp Body"
 
     def mess_body(self, obj):
-        body = ""
-        for message in obj.messenger_body:
-            body = body + message.value["message"]
-        return body
+        body = "\n".join(m.value["message"] for m in obj.messenger_body)
+        return truncatechars(str(body), self.body_truncate_size)
 
     mess_body.short_description = "Messenger Body"
 
     def vib_body(self, obj):
-        body = ""
-        for message in obj.viber_body:
-            body = body + message.value["message"]
-        return body
+        body = "\n".join(m.value["message"] for m in obj.viber_body)
+        return truncatechars(str(body), self.body_truncate_size)
 
     vib_body.short_description = "Viber Body"
 
     def web_body(self, obj):
-        return obj.body
+        return truncatechars(str(obj.body), self.body_truncate_size)
 
     web_body.short_description = "Web Body"
 


### PR DESCRIPTION
## Purpose
When in the list view, the narrow columns and long messages make it difficult to browse when displaying the whole message text

## Approach
For each of the message types, we truncate the body in the list view, and add an elipses if we do so

<img width="1107" alt="image" src="https://github.com/praekeltfoundation/contentrepo/assets/8234653/23830a43-3328-42d4-b9ed-32119c7d839f">

