### PR TITLE
Add progress indicator for content import

### DIFF
--- a/contentrepo/static/js/contentrepo.js
+++ b/contentrepo/static/js/contentrepo.js
@@ -1,23 +1,24 @@
-$(".meter > span").each(function () {
-  $(this)
-    .data("origWidth", $(this).width())
-    .width(0)
-    .animate(
-      {
-        width: $(this).data("origWidth")
-      },
-      1200
-    );
-});
+getUploadStateInterval = null;
 
 function getUploadState(){
- $.ajax({
+ $.getJSON({
   url: importURL,
-  type: 'get',
   success: function(response){
-   if(response != "True"){
+   if(!response.loading){
     window.location.href = destinationURL;
+    clearInterval(getUploadStateInterval)
    }
+   if(response.progress) {
+      $(".meter > span").each(function () {
+        $(this)
+          .animate(
+            {
+              width: response.progress + "%"
+            },
+            1200
+          );
+      });
+    }
   }
  });
 }
@@ -25,6 +26,6 @@ function getUploadState(){
 $(document).ready(function(){
  var loadingBar = document.getElementById("loadingBar");
  if (loadingBar != null){
-    setInterval(getUploadState,1000);
+    getUploadStateInterval = setInterval(getUploadState,1000);
  }
 });

--- a/contentrepo/templates/orderedcontentset_upload.html
+++ b/contentrepo/templates/orderedcontentset_upload.html
@@ -26,7 +26,7 @@
 {% block main_content %}
     {% if loading %}
         <div class="meter animate" id="meter">
-            <span id="loadingBar" style="width: 50%"><span></span></span>
+            <span id="loadingBar" style="width: 1%"><span></span></span>
         </div>
     {% else %}
       <form action="{% url 'import_orderedcontentset' %}" method="POST" enctype="multipart/form-data">

--- a/contentrepo/templates/upload.html
+++ b/contentrepo/templates/upload.html
@@ -26,7 +26,7 @@
 {% block main_content %}
     {% if loading %}
         <div class="meter animate" id="meter">
-            <span id="loadingBar" style="width: 50%"><span></span></span>
+            <span id="loadingBar" style="width: 1%"><span></span></span>
         </div>
     {% else %}
       <form action="{% url 'import' %}" method="POST" enctype="multipart/form-data">

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -1,4 +1,5 @@
 import json
+import queue
 from pathlib import Path
 
 from django.test import Client, TestCase
@@ -20,7 +21,7 @@ class PaginationTestCase(TestCase):
     def setUp(self):
         path = Path("home/tests/content2.csv")
         with path.open(mode="rb") as f:
-            import_content(f, "CSV")
+            import_content(f, "CSV", queue.Queue())
         self.content_page1 = ContentPage.objects.first()
 
     def test_tag_filtering(self):
@@ -213,7 +214,7 @@ class OrderedContentSetTestCase(TestCase):
     def setUp(self):
         path = Path("home/tests/content2.csv")
         with path.open(mode="rb") as f:
-            import_content(f, "CSV")
+            import_content(f, "CSV", queue.Queue())
         self.content_page1 = ContentPage.objects.first()
         self.ordered_content_set = OrderedContentSet.objects.create(
             name="Test set",

--- a/home/utils.py
+++ b/home/utils.py
@@ -669,7 +669,7 @@ def export_csv_content(queryset: PageQuerySet, response: HttpResponse) -> None:
         writer.writerow(row)
 
 
-def import_ordered_sets(file, filetype, purge=False):
+def import_ordered_sets(file, filetype, progress_queue, purge=False):
     def create_ordered_set_from_row(row):
         set_name = row["Name"]
         set_profile_fields = []
@@ -719,10 +719,15 @@ def import_ordered_sets(file, filetype, purge=False):
         for dictionary in reader:
             lines.append(dictionary)
 
+    # 10% progress for loading file
+    progress_queue.put_nowait(10)
+
     for index, row in enumerate(lines):
         os = create_ordered_set_from_row(row)
         if not os:
             print(f"Ordered Content Set not created for row {index + 1}")
+        # 10-100% for loading ordered content sets
+        progress_queue.put_nowait(10 + index * 90 / len(lines))
 
 
 @dataclass

--- a/home/views.py
+++ b/home/views.py
@@ -10,7 +10,7 @@ from django.db.models import Count, F
 from django.db.models.functions import TruncMonth
 from django.forms import MultiWidget
 from django.forms.widgets import NumberInput
-from django.http import HttpResponse, JsonResponse
+from django.http import JsonResponse
 from django.shortcuts import render
 from django.utils.translation import gettext_lazy as _
 from django.views import View
@@ -143,7 +143,9 @@ class ContentUploadThread(UploadThread):
 
     def run(self):
         try:
-            import_content(self.file, self.file_type, self.progress_queue, self.purge, self.locale)
+            import_content(
+                self.file, self.file_type, self.progress_queue, self.purge, self.locale
+            )
         except Exception:
             self.result_queue.put((messages.ERROR, "Content import failed"))
             logger.exception("Content import failed")


### PR DESCRIPTION
## Purpose
For content imports, currently there's a progress bar, but it just stays at 50% until the import is over.

For large imports, this can look like something is broken.

## Approach
Instead of starting the bar at 50%, we start it at 1%.

Then we add an additional queue from the import thread to keep us updated on the progress.

The thread then sends the % complete of the import to that queue, and in the ajax response we fetch the latest value from that queue, and send it in the response.

In order to send it in the response, we also need to switch to sending a JSON ajax response, so that we can send both the progress and whether the task is complete.

https://github.com/praekeltfoundation/contentrepo/assets/8234653/a39cae31-a9f7-4e34-bc3d-48eaa7c28a96


