### PR TITLE
Returning draft and live content on the API

### DIFF
--- a/home/api.py
+++ b/home/api.py
@@ -26,6 +26,7 @@ class ContentPagesViewSet(PagesAPIViewSet):
             "tag",
             "trigger",
             "page",
+            "qa",
         ]
     )
     pagination_class = PageNumberPagination
@@ -47,7 +48,12 @@ class ContentPagesViewSet(PagesAPIViewSet):
         super(ContentPagesViewSet, self).list(self, request, *args, **kwargs)
 
     def get_queryset(self):
-        queryset = super(ContentPagesViewSet, self).get_queryset()
+        qa = self.request.query_params.get("qa")
+        queryset = ContentPage.objects.live()
+
+        if qa:
+            queryset = queryset | ContentPage.objects.not_live()
+
         tag = self.request.query_params.get("tag")
         if tag is not None:
             ids = []

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -156,7 +156,10 @@ class BodyField(serializers.Field):
                     )
                 except IndexError:
                     raise ValidationError("The requested message does not exist")
-        elif "messenger" in request.GET and page.enable_messenger is True:
+        elif "messenger" in request.GET and (
+            page.enable_messenger is True
+            or ("qa" in request.GET and request.GET["qa"] == "True")
+        ):
             if page.messenger_body != []:
                 try:
                     return OrderedDict(
@@ -176,7 +179,10 @@ class BodyField(serializers.Field):
                     )
                 except IndexError:
                     raise ValidationError("The requested message does not exist")
-        elif "viber" in request.GET and page.enable_viber is True:
+        elif "viber" in request.GET and (
+            page.enable_viber is True
+            or ("qa" in request.GET and request.GET["qa"] == "True")
+        ):
             if page.viber_body != []:
                 try:
                     return OrderedDict(

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -127,7 +127,10 @@ class BodyField(serializers.Field):
         else:
             message = 0
 
-        if "whatsapp" in request.GET and (page.enable_whatsapp is True or ("qa" in request.GET and request.GET["qa"] == "True")):
+        if "whatsapp" in request.GET and (
+            page.enable_whatsapp is True
+            or ("qa" in request.GET and request.GET["qa"] == "True")
+        ):
             if page.whatsapp_body != []:
                 try:
                     return OrderedDict(

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -127,7 +127,7 @@ class BodyField(serializers.Field):
         else:
             message = 0
 
-        if "whatsapp" in request.GET and page.enable_whatsapp is True:
+        if "whatsapp" in request.GET and (page.enable_whatsapp is True or ("qa" in request.GET and request.GET["qa"] == "True")):
             if page.whatsapp_body != []:
                 try:
                     return OrderedDict(

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -41,7 +41,8 @@ class PaginationTestCase(TestCase):
         # it should return all pages for no tag
         response = self.client.get("/api/v2/pages/")
         content = json.loads(response.content)
-        self.assertEquals(content["count"], 5)
+        # exclude home pages and index pages
+        self.assertEquals(content["count"], 3)
 
     def test_pagination(self):
         self.client = Client()


### PR DESCRIPTION
We need to have an option to return QA content on the API, we will do this by adding the parameter `qa`

the following things are probably issues 

- The `enable_whatsapp` attribute is not saved when saving draft, so when the page that is `not_live()` is called, the `enable_whatsapp=False`, because of this, we have to add two confitional statements to the serializer to surface the whatsapp content `(page.enable_whatsapp is True or ("qa" in request.GET and request.GET["qa"] == "True"))`
- The previous way of creating the `queryset`, `queryset = super(ContentPagesViewSet, self).get_queryset()`, included `HomePage`'s and `ContentIndexPages`, as can be seen by the `test_api`, this is not the case by calling `ContentPage.objects.live()` and `ContentPage.objects.not_live()`, this might be a problem, but with both, the api doesnt find those two page types if we look for a page on the ID, so the impact of this is uncertain 
- Updated content that is saved as draft on a live page, such that the page is `live + draft` in the admin, I have not yet found a way to add that content to the API 