### PR TITLE
Add v1.0.8 and v1.0.9 to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Made authentication for the API mandatory (#136)
+
+
+## v0.0.109
+
 ### Added
 
-- Made authentication for the API mandatory
+- Success and failure messages for imports (#141)
+- Support for stage based messaging in ordered content sets (#143)
+- Return draft content on the API with query parameter (#144)
+
+### Changed
+
+- Truncate message bodies in admin list view (#139)
+- Progress indicators for imports change according to import progress (#142)
+
+### Fixed
+
+- Handle site settings not yet created properly (#140)
+
+
+## v0.0.108
+
+This release adds an index concurrently, which is a postgresql-only feature. This means that from this release forward, only the postgresql database backend is supported.
+
+### Added
+
+- Documented the release plan (#135)
+- Redirect to wagtail admin from homepage (#137)
+
+### Changed
+
+- Indexed the timestamp field for page views (#134)
+
+### Fixed
+
+- Return appropriate error for page not found, instead of uncaught server error (#138)


### PR DESCRIPTION
## Purpose
Make sure that we start documenting changes in the changelog

## Approach
We start by documenting the last two releases, and we'll continue documenting future releases as we carry on

