### PR TITLE
Trying to surface published pages with draft content

### DIFF
--- a/home/api.py
+++ b/home/api.py
@@ -52,8 +52,8 @@ class ContentPagesViewSet(PagesAPIViewSet):
         return super().detail_view(request, pk)
 
     @method_decorator(cache_page(60 * 60 * 2))
-    def list(self, request, *args, **kwargs):
-        super(ContentPagesViewSet, self).list(self, request, *args, **kwargs)
+    def listing_view(self, request, *args, **kwargs):
+        return super().listing_view(request)
 
     def get_queryset(self):
         qa = self.request.query_params.get("qa")

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -56,7 +56,7 @@ class PaginationTestCase(TestCase):
         # exclude home pages and index pages
         self.assertEquals(content["count"], 3)
         # it should not return pages with tags in the draft
-        page = create_page(tags=["Menu"])
+        create_page(tags=["Menu"])
         response = self.client.get("/api/v2/pages/?tag=Menu")
         content = json.loads(response.content)
         self.assertEquals(content["count"], 1)

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -55,6 +55,15 @@ class PaginationTestCase(TestCase):
         content = json.loads(response.content)
         # exclude home pages and index pages
         self.assertEquals(content["count"], 3)
+        # it should not return pages with tags in the draft
+        page = create_page(tags=["Menu"])
+        response = self.client.get("/api/v2/pages/?tag=Menu")
+        content = json.loads(response.content)
+        self.assertEquals(content["count"], 1)
+        # If QA flag is sent then it should return pages with tags in the draft
+        response = self.client.get("/api/v2/pages/?tag=Menu&qa=True")
+        content = json.loads(response.content)
+        self.assertEquals(content["count"], 2)
 
     def test_whatsapp_draft(self):
         self.content_page2.unpublish()


### PR DESCRIPTION
Tags & Triggers dont created tagged objects on draft save - this is a problem when hitting the api with a tag or trigger parameter, this is not a problem in the actual content, that is why quick replies are not an issue