### PR TITLE
Api filter pages by platform

### DIFF
--- a/home/api.py
+++ b/home/api.py
@@ -22,16 +22,7 @@ from .models import (  # isort:skip
 class ContentPagesViewSet(PagesAPIViewSet):
     base_serializer_class = ContentPageSerializer
     known_query_parameters = PagesAPIViewSet.known_query_parameters.union(
-        [
-            "tag",
-            "trigger",
-            "page",
-            "qa",
-            "whatsapp",
-            "viber",
-            "messenger",
-            "web"
-        ]
+        ["tag", "trigger", "page", "qa", "whatsapp", "viber", "messenger", "web"]
     )
     pagination_class = PageNumberPagination
 

--- a/home/api.py
+++ b/home/api.py
@@ -27,6 +27,10 @@ class ContentPagesViewSet(PagesAPIViewSet):
             "trigger",
             "page",
             "qa",
+            "whatsapp",
+            "viber",
+            "messenger",
+            "web"
         ]
     )
     pagination_class = PageNumberPagination
@@ -53,6 +57,15 @@ class ContentPagesViewSet(PagesAPIViewSet):
 
         if qa:
             queryset = queryset | ContentPage.objects.not_live()
+
+        if "web" in self.request.query_params:
+            queryset = queryset.filter(enable_web=True)
+        elif "whatsapp" in self.request.query_params:
+            queryset = queryset.filter(enable_whatsapp=True)
+        elif "messenger" in self.request.query_params:
+            queryset = queryset.filter(enable_messenger=True)
+        elif "viber" in self.request.query_params:
+            queryset = queryset.filter(enable_viber=True)
 
         tag = self.request.query_params.get("tag")
         if tag is not None:

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -148,15 +148,15 @@ class PaginationTestCase(TestCase):
         self.assertEquals(content["body"]["text"]["message"].replace("\r", ""), message)
 
     def test_pagination(self):
-        # it should return the web body if enable_whatsapp=false
+        # it should not return the web body if enable_whatsapp=false
         self.content_page1.enable_whatsapp = False
         self.content_page1.save_revision().publish()
         response = self.client.get(
             f"/api/v2/pages/{self.content_page1.id}/?whatsapp=True"
         )
-        content = json.loads(response.content)
-        self.assertNotEquals(content["body"]["text"], "Whatsapp Body 1")
-        self.assertEquals(content["body"]["text"], [])
+
+        content = response.content
+        self.assertEquals(content, b"")
 
         # it should only return the whatsapp body if enable_whatsapp=True
         self.content_page1.enable_whatsapp = True

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -68,7 +68,9 @@ class PaginationTestCase(TestCase):
         self.content_page2.enable_viber = False
         self.content_page2.save_revision().publish()
         # messenger page
-        [page3] = ContentPage.objects.exclude(pk__in=[self.content_page1,self.content_page2])[:1]
+        [page3] = ContentPage.objects.exclude(
+            pk__in=[self.content_page1, self.content_page2]
+        )[:1]
         page3.enable_web = False
         page3.enable_whatsapp = False
         page3.enable_viber = False

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -56,6 +56,46 @@ class PaginationTestCase(TestCase):
         # exclude home pages and index pages
         self.assertEquals(content["count"], 3)
 
+    def test_platform_filtering(self):
+        # web page
+        self.content_page1.enable_messenger = False
+        self.content_page1.enable_whatsapp = False
+        self.content_page1.enable_viber = False
+        self.content_page1.save_revision().publish()
+        # whatsapp page
+        self.content_page2.enable_messenger = False
+        self.content_page2.enable_web = False
+        self.content_page2.enable_viber = False
+        self.content_page2.save_revision().publish()
+        # messenger page
+        [page3] = ContentPage.objects.exclude(pk__in=[self.content_page1,self.content_page2])[:1]
+        page3.enable_web = False
+        page3.enable_whatsapp = False
+        page3.enable_viber = False
+        page3.save_revision().publish()
+
+        # it should return only web pages if filtered
+        response = self.client.get("/api/v2/pages/?web=true")
+        content = json.loads(response.content)
+        self.assertEquals(content["count"], 1)
+        # it should return only whatsapp pages if filtered
+        response = self.client.get("/api/v2/pages/?whatsapp=true")
+        content = json.loads(response.content)
+        self.assertEquals(content["count"], 1)
+        # it should return only messenger pages if filtered
+        response = self.client.get("/api/v2/pages/?messenger=true")
+        content = json.loads(response.content)
+        self.assertEquals(content["count"], 1)
+        # it should return only viber pages if filtered
+        response = self.client.get("/api/v2/pages/?viber=true")
+        content = json.loads(response.content)
+        self.assertEquals(content["count"], 0)
+        # it should return all pages for no filter
+        response = self.client.get("/api/v2/pages/")
+        content = json.loads(response.content)
+        # exclude home pages and index pages
+        self.assertEquals(content["count"], 3)
+
     def test_whatsapp_draft(self):
         self.content_page2.unpublish()
         page_id = self.content_page2.id


### PR DESCRIPTION
## Purpose
_The page list returned by the API should be filterable by platform._

## Approach
_This accepts requests that contain a parameter for filtering by the platform and returns the filtered list_

#### Open Questions and Pre-Merge TODOs
- [ ] This removes the ability to fallback to the web page as the default for the detail view if the page doesn't exist on the filtered platform.
