### PR TITLE
Fix charater limit validation

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.validators import MaxLengthValidator
 from django.db import models
 from django.forms import CheckboxSelectMultiple
 from modelcluster.contrib.taggit import ClusterTaggableManager
@@ -7,6 +8,7 @@ from modelcluster.fields import ParentalKey
 from taggit.models import ItemBase, TagBase, TaggedItemBase
 from wagtail import blocks
 from wagtail.api import APIField
+from wagtail.blocks import StructBlockValidationError
 from wagtail.contrib.settings.models import BaseSiteSetting, register_setting
 from wagtail.documents.blocks import DocumentChooserBlock
 from wagtail.fields import StreamField
@@ -153,8 +155,8 @@ class VariationBlock(blocks.StructBlock):
         use_json_field=True,
     )
     message = blocks.TextBlock(
-        max_lenth=4096,
         help_text="each message cannot exceed 4096 characters.",
+        validators=(MaxLengthValidator(4096),),
     )
 
 
@@ -165,11 +167,15 @@ class WhatsappBlock(blocks.StructBlock):
     document = DocumentChooserBlock(icon="document", required=False)
     media = MediaBlock(icon="media", required=False)
     message = blocks.TextBlock(
-        max_lenth=4096, help_text="each message cannot exceed 4096 characters."
+        help_text="each text message cannot exceed 4096 characters, messages with "
+        "media cannot exceed 1024 characters.",
+        validators=(MaxLengthValidator(4096),),
     )
     variation_messages = blocks.ListBlock(VariationBlock(), default=[])
     next_prompt = blocks.CharBlock(
-        max_length=20, help_text="prompt text for next message", required=False
+        help_text="prompt text for next message",
+        required=False,
+        validators=(MaxLengthValidator(20),),
     )
 
     class Meta:
@@ -200,7 +206,8 @@ class WhatsappBlock(blocks.StructBlock):
 class ViberBlock(blocks.StructBlock):
     image = ImageChooserBlock(required=False)
     message = blocks.TextBlock(
-        max_lenth=7000, help_text="each message cannot exceed 7000 characters."
+        help_text="each message cannot exceed 7000 characters.",
+        validators=(MaxLengthValidator(7000),),
     )
 
     class Meta:
@@ -211,7 +218,8 @@ class ViberBlock(blocks.StructBlock):
 class MessengerBlock(blocks.StructBlock):
     image = ImageChooserBlock(required=False)
     message = blocks.TextBlock(
-        max_lenth=2000, help_text="each message cannot exceed 2000 characters."
+        help_text="each message cannot exceed 2000 characters.",
+        validators=(MaxLengthValidator(2000),),
     )
 
     class Meta:


### PR DESCRIPTION
- Ensure that whatsapp media message length error is shown in the correct place
- Use MaxLengthValidator since max_length does nothing for TextBlock

## Purpose
An issue was picked up that the only message length validation that worked was the whatsapp media message.

The help text for whatsapp messages also didn't mention that media messages could only have 1024 characters instead of the regular 4096 characters

## Approach
The custom cleaning logic was moved into the WhatsappBlock. This allows the error message to be displayed in the correct position in the UI, since it's now tied to the message field in the correct whatsapp message, instead of a general error.

The max_length definitions for TextBlocks don't do any validation, so those were replaced with a MaxLengthValidator

