### PR TITLE
Fix validation for whatsapp media message character limit

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -186,8 +186,8 @@ class WhatsappBlock(blocks.StructBlock):
         result = super().clean(value)
 
         if (result["image"] or result["document"] or result["media"]) and len(
-            result["message"] > self.MEDIA_CAPTION_MAX_LENGTH
-        ):
+            result["message"]
+        ) > self.MEDIA_CAPTION_MAX_LENGTH:
             raise StructBlockValidationError(
                 {
                     "message": ValidationError(


### PR DESCRIPTION
## Purpose
Currently we're getting an error when adding an image, because there are brackets in the incorrect place on the custom message length validation for whatsapp media messages, causing a runtime TypeError

## Approach
The brackets are fixed, leading to correct logic. Unit tests are added to make sure that this logic is working as expected
