### PR TITLE
Add management command to update content embeddings for all pages

### DIFF
--- a/contentrepo/settings/base.py
+++ b/contentrepo/settings/base.py
@@ -265,4 +265,6 @@ EMAIL_SSL_CERTFILE = env.str("EMAIL_SSL_CERTFILE", None)
 EMAIL_SSL_KEYFILE = env.str("EMAIL_SSL_KEYFILE", None)
 EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT", None)
 
+# Flag for turning on the transformation model
+# When changing this consider running update_content_embeddings management cmd
 LOAD_TRANSFORMER_MODEL = env.bool("LOAD_TRANSFORMER_MODEL", False)

--- a/home/constants.py
+++ b/home/constants.py
@@ -22,6 +22,8 @@ RELATIONSHIP_STATUS_CHOICES = [
     ("empty", "Empty"),
 ]
 
+# The model used to identify embeddings in content
+# When changing this consider running update_content_embeddings management cmd
 model = None
 if settings.LOAD_TRANSFORMER_MODEL:
     model = SentenceTransformer("all-mpnet-base-v2")

--- a/home/management/commands/update_content_embeddings.py
+++ b/home/management/commands/update_content_embeddings.py
@@ -1,7 +1,4 @@
-import json
-
 from django.core.management.base import BaseCommand
-from wagtail.models import Page
 
 from home.models import ContentPage
 
@@ -15,8 +12,6 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        pages = (
-            ContentPage.objects.live()
-        )
+        pages = ContentPage.objects.live()
         for page in pages:
             page.save()

--- a/home/management/commands/update_content_embeddings.py
+++ b/home/management/commands/update_content_embeddings.py
@@ -1,0 +1,22 @@
+import json
+
+from django.core.management.base import BaseCommand
+from wagtail.models import Page
+
+from home.models import ContentPage
+
+
+class Command(BaseCommand):
+    help = (
+        "Updates the embeddings for all live ContentPages. "
+        "Intended to be run when sentence transformation is turned on for an instance "
+        "so that existing content has embeddings saved."
+        "Does not create a new revision and does not publish pages after saving."
+    )
+
+    def handle(self, *args, **options):
+        pages = (
+            ContentPage.objects.live()
+        )
+        for page in pages:
+            page.save()


### PR DESCRIPTION
## Purpose
Existing instances of content repo may have content that already exists and doesn't need updates. This allows us to update the embeddings if the model is turned on or changed