### PR TITLE
Roll back failed content imports

### DIFF
--- a/home/content_import_export.py
+++ b/home/content_import_export.py
@@ -8,6 +8,7 @@ from logging import getLogger
 from math import ceil
 from typing import List, Tuple, Union
 
+from django.db import transaction
 from django.http import HttpResponse
 from openpyxl import load_workbook
 from openpyxl.styles import Border, Color, Font, NamedStyle, PatternFill, Side
@@ -70,6 +71,7 @@ EXPORT_FIELDNAMES = [
 logger = getLogger(__name__)
 
 
+@transaction.atomic
 def import_content(file, filetype, progress_queue, purge=True, locale="en"):
     def set_variation_blocks(body_values, message_number):
         variation_blocks = []

--- a/home/tests/broken.csv
+++ b/home/tests/broken.csv
@@ -1,0 +1,2 @@
+this,is,not,a,valid,content,csv
+"For real, it's totally not."


### PR DESCRIPTION
## Purpose
We probably don't want a partial/broken set of content in the db if an import fails. Doing the import in a transaction can cover most cases.

## Approach
Wrap the `import_content` function in `transaction.atomic` to roll back if any exceptions are raised.

This won't save us from "successful" imports that leave us in a bad state, but it's a start.