### PR TITLE
Disable cache in dev settings to avoid interfering with tests

### DIFF
--- a/contentrepo/settings/dev.py
+++ b/contentrepo/settings/dev.py
@@ -14,3 +14,12 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 WHATSAPP_API_URL = "http://whatsapp"
 WHATSAPP_ACCESS_TOKEN = "fake-access-token"  # noqa: S105 (This is a test config.)
 FB_BUSINESS_ID = "27121231234"
+
+
+# NOTE: We don't want the cache getting in the way during tests, but this also
+# means we're not testing the cache behaviour.
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+    }
+}

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -56,7 +56,7 @@ class PaginationTestCase(TestCase):
         # exclude home pages and index pages
         self.assertEqual(content["count"], 3)
         # it should not return pages with tags in the draft
-        create_page(tags=["Menu"])
+        create_page(tags=["Menu"]).unpublish()
         response = self.client.get("/api/v2/pages/?tag=Menu")
         content = json.loads(response.content)
         self.assertEqual(content["count"], 1)

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -238,14 +238,8 @@ class PaginationTestCase(TestCase):
         self.assertEqual(content["body"]["text"]["value"]["message"], "WA Message 11")
 
     def test_number_of_queries(self):
-        DUMMY_CACHE = {
-            "default": {
-                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-            }
-        }
-        with self.settings(CACHES=DUMMY_CACHE):
-            with self.assertNumQueries(14):
-                self.client.get("/api/v2/pages/")
+        with self.assertNumQueries(14):
+            self.client.get("/api/v2/pages/")
 
     def test_detail_view(self):
         ContentPage.objects.all().delete()


### PR DESCRIPTION
## Purpose
Having the cache enabled during tests can introduce unintentional coupling between tests and can interfere with tests that make multiple requests. If we want to test caching, we should enable if for specific tests only.