### PR TITLE
Run lints/test even when others fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
+        exit 1  # FIXME: Temp failure to check that future steps don't run.
     - name: Check formatting
       # Lints/tests should always run, even if other lints/tests have failed.
       if: success() || failure() && steps.install-deps.outcome == 'success'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-        exit 1  # FIXME: Temp failure to check that future steps don't run.
     - name: Check formatting
       # Lints/tests should always run, even if other lints/tests have failed.
       if: success() || failure() && steps.install-deps.outcome == 'success'
       run: |
         black --check .
-        exit 1  # FIXME: Temp failure to check that future steps run.
     - name: Lint
       if: success() || failure() && steps.install-deps.outcome == 'success'
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,15 +27,26 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      id: install-deps
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-    - name: Lint
+    - name: Check formatting
+      # Lints/tests should always run, even if other lints/tests have failed.
+      if: success() || failure() && steps.install-deps.outcome == "success"
       run: |
         black --check .
+        exit 1  # FIXME: Temp failure to check that future steps run.
+    - name: Lint
+      if: success() || failure() && steps.install-deps.outcome == "success"
+      run: |
         ruff .
+    - name: Check types
+      if: success() || failure() && steps.install-deps.outcome == "success"
+      run: |
         mypy
     - name: Run tests
+      if: success() || failure() && steps.install-deps.outcome == "success"
       run: |
         pytest -vv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,19 +34,19 @@ jobs:
         pip install -r requirements-dev.txt
     - name: Check formatting
       # Lints/tests should always run, even if other lints/tests have failed.
-      if: success() || failure() && steps.install-deps.outcome == "success"
+      if: success() || failure() && steps.install-deps.outcome == 'success'
       run: |
         black --check .
         exit 1  # FIXME: Temp failure to check that future steps run.
     - name: Lint
-      if: success() || failure() && steps.install-deps.outcome == "success"
+      if: success() || failure() && steps.install-deps.outcome == 'success'
       run: |
         ruff .
     - name: Check types
-      if: success() || failure() && steps.install-deps.outcome == "success"
+      if: success() || failure() && steps.install-deps.outcome == 'success'
       run: |
         mypy
     - name: Run tests
-      if: success() || failure() && steps.install-deps.outcome == "success"
+      if: success() || failure() && steps.install-deps.outcome == 'success'
       run: |
         pytest -vv

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,9 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - "*"
+    # FIXME: Temporarily disabled for this branch.
+    # branches:
+    #   - "*"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,8 @@ on:
   push:
     tags:
       - "v*"
-    # FIXME: Temporarily disabled for this branch.
-    # branches:
-    #   - "*"
+    branches:
+      - "*"
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
## Purpose
We want results from all lints and tests, even if previous ones have failed. The build should still fail if any step fails, though.

## Approach
Split up lints and add success/failure conditions to the lint and test steps.