### PR TITLE
Remove additional delete on purge

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -272,8 +272,6 @@ class ContentUploadView(View):
     def post(self, request, *args, **kwargs):
         form = self.form_class(request.POST, request.FILES)
         if form.is_valid():
-            if form.cleaned_data["purge"] == "True":
-                ContentPage.objects.all().delete()
             ContentUploadThread(
                 form.cleaned_data["purge"],
                 form.cleaned_data["locale"],


### PR DESCRIPTION
## Purpose
Currently there are two places where we perform a delete. We delete all
the ContentPages in the view, and then in the background task we delete
all the ContentPages, and all the index pages, and we do that in a
transaction.

This causes an issue for invalid purge imports, since they'll delete all
the content pages outside of the transaction, so if there's an issue and
the transaction gets rolled back, the content is still deleted.

## Approach
We should remove the delete in the view, and just have the import
task take care of deleting for the purge option
