### PR TITLE
Handle missing fields when submitting whatsapp templates

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -642,15 +642,19 @@ class ContentPage(Page, ContentImportMixin):
             return
         if not self.is_whatsapp_template:
             return
+
+        # If there are any missing fields in the previous revision, then carry on
         try:
             previous_revision = previous_revision.as_object()
-            if (
-                self.whatsapp_template_fields
-                == previous_revision.whatsapp_template_fields
-            ):
+            previous_revision_fields = previous_revision.whatsapp_template_fields
+        except (IndexError, AttributeError):
+            previous_revision_fields = ()
+        # If there are any missing fields in this revision, then don't submit template
+        try:
+            if self.whatsapp_template_fields == previous_revision_fields:
                 return
-        except AttributeError:
-            pass
+        except (IndexError, AttributeError):
+            return
 
         self.whatsapp_template_name = self.create_whatsapp_template_name()
 

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -4,8 +4,15 @@ from django.test import TestCase, override_settings
 from wagtail.blocks import StructBlockValidationError
 from wagtail.images import get_image_model
 
-from home.models import GoToPageButton, NextMessageButton, PageView, WhatsappBlock
+from home.models import (
+    GoToPageButton,
+    HomePage,
+    NextMessageButton,
+    PageView,
+    WhatsappBlock,
+)
 
+from .page_builder import PageBuilder, WABlk, WABody
 from .utils import create_page, create_page_rating
 
 
@@ -175,6 +182,58 @@ class ContentPageTests(TestCase):
             None,
             [],
         )
+
+    @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
+    @mock.patch("home.models.create_whatsapp_template")
+    def test_template_submitted_with_no_whatsapp_previous_revision(
+        self, mock_create_whatsapp_template
+    ):
+        """
+        If the previous revision didn't have any whatsapp messages, it should still
+        successfully submit a whatsapp template
+        """
+        home_page = HomePage.objects.first()
+        main_menu = PageBuilder.build_cpi(home_page, "main-menu", "Main Menu")
+        page = PageBuilder.build_cp(
+            parent=main_menu,
+            slug="ha-menu",
+            title="HealthAlert menu",
+            bodies=[],
+        )
+        wa_block = WABody("WA Title", [WABlk("Test WhatsApp Message 1")])
+        wa_block.set_on(page)
+        page.is_whatsapp_template = True
+        page.save_revision()
+
+        expected_template_name = f"WA_Title_{page.get_latest_revision().pk}"
+        mock_create_whatsapp_template.assert_called_once_with(
+            expected_template_name,
+            "Test WhatsApp Message 1",
+            "UTILITY",
+            [],
+            None,
+            [],
+        )
+
+    @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
+    @mock.patch("home.models.create_whatsapp_template")
+    def test_template_not_submitted_with_no_message(
+        self, mock_create_whatsapp_template
+    ):
+        """
+        If the page doesn't have any whatsapp messages, then it shouldn't be submitted
+        """
+        home_page = HomePage.objects.first()
+        main_menu = PageBuilder.build_cpi(home_page, "main-menu", "Main Menu")
+        PageBuilder.build_cp(
+            parent=main_menu,
+            slug="ha-menu",
+            title="HealthAlert menu",
+            bodies=[],
+            whatsapp_template_name="WA_Title_1",
+        )
+
+        mock_create_whatsapp_template.assert_not_called()
 
 
 class WhatsappBlockTests(TestCase):


### PR DESCRIPTION
## Purpose
Currently for whatsapp templates, we assume that there is at least one whatsapp message, and that the first message is the template that we want to submit.

This leads to uncaught errors when a template is saved without any whatsapp messages.

## Approach
We catch and handle the errors when a template is saved without any whatsapp messages.

There are two places that this could happen. Firstly, when we're getting the details of the previous version of the page, that could have no whatsapp messages. In this case, we want to carry on with submitting the template. Then, when we're getting the details of the current version of the page, that could also not have any whatsapp messages. In this case we want to not submit the template.
