### PR TITLE
Remove cache from list endpoints.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         postgres_version: ['12', '13', '14']
         python-version: [3.10.6]
+        redis-version: ['7.2']
     services:
       postgres:
         image: postgres:${{ matrix.postgres_version }}
@@ -18,8 +19,13 @@ jobs:
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
+      redis:
+        image: redis:${{ matrix.redis_version }}
+        ports:
+          - 6372:6372
     env:
       CONTENTREPO_DATABASE: postgres://postgres:postgres@localhost:5432/contentrepo
+      CACHE_URL: redis://localhost:6372/0
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         ports:
           - 5432:5432
       redis:
-        image: redis:${{ matrix.redis_version }}
+        image: redis:${{ matrix.redis-version }}
         ports:
           - 6372:6372
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
       redis:
         image: redis:${{ matrix.redis-version }}
         ports:
-          - 6372:6372
+          - 6379:6379
     env:
       CONTENTREPO_DATABASE: postgres://postgres:postgres@localhost:5432/contentrepo
-      CACHE_URL: redis://localhost:6372/0
+      CACHE_URL: redis://localhost:6379/0
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- `REDIS_LOCATION` as been changed to `CACHE_URL`, and now supports a wide range of cache backends. `REDIS_LOCATION` will still work, and is an alias for, and takes priority over `CACHE_URL`.
+- Remove cache on list endpoint. There's no way to invalidate this cache, and at this point in time we're not sure if it's necessary, but it was creating issues in that the list endpoint would be out of date, so it has been removed for now. If it's needed in the future, it will be added back, but in a way that allows us to invalidate it on changes, or with a very short TTL.
+
+
 ## v1.1.0-dev.4
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ The current LTS release is: 1.0
 
 ### Redis
 
+For development environments, Redis is optional, it will use an in-memory cache by
+default if the environment variable isn't specified.
+
 For Linux and WSL2 (Windows Subsystem for Linux)
  Creating a docker container with the ports exposed, called `cr_redis`
 `docker run -d -p 6379:6379 --name cr_redis redis`
@@ -60,7 +63,7 @@ For Linux and WSL2 (Windows Subsystem for Linux)
 To then run the docker container,
 `docker run cr_redis`
 
-This can work for mac and (possibly Windows) by setting the environment variable `DATABASE_URL=postgres://postgres@0.0.0.0/contentrepo`
+This can work for mac and (possibly Windows) by setting the environment variable `CACHE=redis://0.0.0.0:6379/0`
 
 ### Postgres
 
@@ -101,7 +104,7 @@ There is a [docker image](https://github.com/praekeltfoundation/contentrepo/pkgs
 | DATABASE_URL  | Where to find the database. Set to `postgresql://host:port/db` for a postgresql database |
 | ALLOWED_HOSTS | Comma separated list of hostnames for this service, eg. `host1.example.org,host2.example.org` |
 | CSRF_TRUSTED_ORIGINS | A list of trusted origins for unsafe requests  |
-| REDIS_LOCATION | Where to find redis, format: redis://host:post/db |
+| CACHE_URL | Where to find the cache backend, format: redis://host:post/db . See [the django-environ docs](https://django-environ.readthedocs.io/en/latest/types.html#environ-env-cache-url) for more cache backends. |
 | SENTRY_DSN | Where to send exceptions to |
 | AWS_ACCESS_KEY_ID | Specifies an AWS access key associated with an IAM account |
 | AWS_SECRET_ACCESS_KEY | Specifies the secret key associated with the access key. This is essentially the "password" for the access key |

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For Linux and WSL2 (Windows Subsystem for Linux)
 To then run the docker container,
 `docker run cr_redis`
 
-This can work for mac and (possibly Windows) by setting the environment variable `CACHE=redis://0.0.0.0:6379/0`
+This can work for mac and (possibly Windows) by setting the environment variable `CACHE_URL=redis://0.0.0.0:6379/0`
 
 ### Postgres
 

--- a/contentrepo/settings/base.py
+++ b/contentrepo/settings/base.py
@@ -177,15 +177,10 @@ WAGTAILADMIN_BASE_URL = os.environ.get("BASE_URL", "http://example.com")
 
 WAGTAILCONTENTIMPORT_DEFAULT_MAPPER = "home.mappers.ContentMapper"
 
-CACHES = {
-    "default": {
-        "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": os.environ.get("REDIS_LOCATION", "redis://127.0.0.1:6379/1"),
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-        },
-    }
-}
+if "REDIS_LOCATION" in os.environ:
+    os.environ["CACHE_URL"] = os.environ["REDIS_LOCATION"]
+
+CACHES = {"default": env.cache("CACHE_URL", default="redis://127.0.0.1:6379/1")}
 
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",

--- a/contentrepo/settings/dev.py
+++ b/contentrepo/settings/dev.py
@@ -16,10 +16,6 @@ WHATSAPP_ACCESS_TOKEN = "fake-access-token"  # noqa: S105 (This is a test config
 FB_BUSINESS_ID = "27121231234"
 
 
-# NOTE: We don't want the cache getting in the way during tests, but this also
-# means we're not testing the cache behaviour.
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-    }
-}
+# We default to using local memory for dev and tests, so that Redis isn't a dependancy
+# We test against Redis in the CI
+CACHES = {"default": env.cache("CACHE_URL", default="locmemcache://")}

--- a/home/api.py
+++ b/home/api.py
@@ -1,5 +1,3 @@
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 from rest_framework.exceptions import ValidationError
 from rest_framework.filters import SearchFilter
 from rest_framework.pagination import PageNumberPagination
@@ -28,10 +26,6 @@ class ContentPagesViewSet(PagesAPIViewSet):
     )
     pagination_class = PageNumberPagination
 
-    @method_decorator(cache_page(60 * 60 * 2))
-    def get(self, request, *args, **kwargs):
-        super(ContentPagesViewSet, self).get(self, request, *args, **kwargs)
-
     def detail_view(self, request, pk):
         try:
             if "qa" in request.GET and request.GET["qa"] == "True":
@@ -47,7 +41,6 @@ class ContentPagesViewSet(PagesAPIViewSet):
 
         return super().detail_view(request, pk)
 
-    @method_decorator(cache_page(60 * 60 * 2))
     def listing_view(self, request, *args, **kwargs):
         # If this request is flagged as QA then we should display the pages that have the filtering tags
         # or triggers in their draft versions
@@ -138,14 +131,6 @@ class OrderedContentSetViewSet(BaseAPIViewSet):
     pagination_class = PageNumberPagination
     search_fields = ["name", "profile_fields"]
     filter_backends = (SearchFilter,)
-
-    @method_decorator(cache_page(60 * 60 * 2))
-    def get(self, request, *args, **kwargs):
-        super(OrderedContentSetViewSet, self).get(self, request, *args, **kwargs)
-
-    @method_decorator(cache_page(60 * 60 * 2))
-    def list(self, request, *args, **kwargs):
-        super(OrderedContentSetViewSet, self).list(self, request, *args, **kwargs)
 
 
 api_router = WagtailAPIRouter("wagtailapi")

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -242,7 +242,7 @@ class PaginationTestCase(TestCase):
         self.assertEqual(content["body"]["text"]["value"]["message"], "WA Message 11")
 
     def test_number_of_queries(self):
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(8):
             self.client.get("/api/v2/pages/")
 
     def test_detail_view(self):


### PR DESCRIPTION
## Purpose
This cache was causing issues with the list endpoints being out of date, since it was set with a very long TTL.

## Approach
There's no way to invalidate this cache on changes, since the key is derived from query string parameters, and Accept and Cookie headers in the request, things that we don't have access to when a page is being changed on the admin.

If it's needed in the future, we will add it back, either with a very short timeout, or a more direct cache that will cache only the things we need, with cache keys that we can delete on changes.