### PR TITLE
Add slug autofill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!--
 ## Unreleased
 
+### Fixed
+- Autofill for empty slug
+
 ### Added
 
 ### Changed
+- Moved slug uniqueness validation to the model validation/clean
+- Empty slugs will auto-generate a unique slug, but if a duplicate slug is specified the user will get a validation error instead of their chosen slug getting overwritten with a unique one.
+- Slug uniqueness is per-locale
+
 -->
 
 ## v1.1.0-dev.5

--- a/home/tests/test_unique_slug_hook.py
+++ b/home/tests/test_unique_slug_hook.py
@@ -1,7 +1,7 @@
+from django.core.exceptions import ValidationError
 from django.test import TestCase
-from wagtail.models import Page
 
-from home.wagtail_hooks import create_unique_slug
+from home.models import ContentPage, HomePage
 
 
 class UniqueSlugHookTest(TestCase):
@@ -9,8 +9,28 @@ class UniqueSlugHookTest(TestCase):
         """
         If the slug exists, append a number so that it's a new slug
         """
-        home = Page.objects.first()
-        home.add_child(instance=Page(title="duplicate", slug="duplicate"))
-        home.add_child(instance=Page(title="duplicate", slug="duplicate-2"))
-        slug = create_unique_slug("duplicate")
+        home = HomePage.objects.first()
+        home.add_child(instance=ContentPage(title="duplicate", slug="duplicate"))
+        home.add_child(instance=ContentPage(title="duplicate", slug="duplicate-2"))
+        slug = ContentPage().get_unique_slug("duplicate")
         self.assertEqual(slug, "duplicate-3")
+
+    def test_duplicate_slug_on_creation(self):
+        """
+        If there's no slug specified, a unique one should be generated
+        """
+        home = HomePage.objects.first()
+        page1 = home.add_child(instance=ContentPage(title="duplicate"))
+        page2 = home.add_child(instance=ContentPage(title="duplicate"))
+        self.assertEqual(page1.slug, "duplicate")
+        self.assertEqual(page2.slug, "duplicate-2")
+
+    def test_duplicate_slug_error(self):
+        """
+        If a slug already exists, an error should be raised
+        """
+        home = HomePage.objects.first()
+        home.add_child(instance=ContentPage(title="duplicate", slug="duplicate"))
+        with self.assertRaises(ValidationError) as e:
+            home.add_child(instance=ContentPage(title="duplicate", slug="duplicate"))
+        self.assertIn("slug", e.exception.error_dict)

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -4,7 +4,6 @@ from wagtail import hooks
 from wagtail.admin import widgets as wagtailadmin_widgets
 from wagtail.admin.menu import AdminOnlyMenuItem
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
-from wagtail.models import Page
 
 from .models import ContentPage, OrderedContentSet
 
@@ -192,41 +191,3 @@ class OrderedContentSetAdmin(ModelAdmin):
 # Now you just need to register your customised ModelAdmin class with Wagtail
 modeladmin_register(ContentPageAdmin)
 modeladmin_register(OrderedContentSetAdmin)
-
-
-@hooks.register("before_edit_page")
-def validate_slug_before_edit(request, page):
-    if request.POST.get("slug") == page.slug:
-        return
-
-    slug = create_unique_slug(request.POST.get("slug"))
-    if slug:
-        post = request.POST.copy()
-        post["slug"] = slug
-        request.POST = post
-
-
-@hooks.register("before_create_page")
-def validate_slug_before_create(request, parent_page, page_class):
-    slug = create_unique_slug(request.POST.get("slug"))
-    if slug:
-        post = request.POST.copy()
-        post["slug"] = slug
-        request.POST = post
-
-
-def create_unique_slug(slug):
-    """
-    If the slug already exists in the database, appends a number to the slug to ensure
-    that the slug is unique
-    """
-    if not slug:
-        return
-
-    suffix = 1
-    candidate_slug = slug
-    while Page.objects.filter(slug=candidate_slug).exists():
-        suffix += 1
-        candidate_slug = f"{slug}-{suffix}"
-
-    return candidate_slug


### PR DESCRIPTION
## Purpose
Instead of requiring the content admin to fill in a slug when creating a new page, we should fill it in automatically, by slugifying the page title. We should also ensure that the slug we're generating is unique.

## Approach
We create a mixin, as that allows us to apply the same slug logic to all our page models.

For new pages, this mixin will generate a slug that's unique to the locale. For existing pages, it will ensure that the slug is unique.

We also need to allow blank for the slug, to stop the form validation from marking empty slugs as an error, since we will now be automatically filling it in.
