### PR TITLE
No xdist by default, add test stuff to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Empty slugs will auto-generate a unique slug, but if a duplicate slug is specified the user will get a validation error instead of their chosen slug getting overwritten with a unique one.
 - Slug uniqueness is per-locale
 - Test speedups. Tests now run in parallel by default, and there's a separate contentrepo/settings/test.py for test-specific settings.
+- Tests no longer run in parallel by default, because the output is a little less clear and the speedup is negligible on some systems.
 
 -->
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ This can work for mac and (possibly Windows) by setting the environment variable
 
 ### Postgres
 
+Local tests run using in-memory sqlite, so postgres isn't required.
+
 For Linux and WSL2 (Windows Subsystem for Linux)
 Creating a docker container that doesnt require a password and matches the setup of the database in settings
 `docker run --name cr_postgres -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_USER=postgres -e POSTGRES_DB=contentrepo -d postgres:latest`
@@ -86,6 +88,10 @@ createdb contentrepo
 ./manage.py createsuperuser
 ./manage.py runserver
 ```
+
+### Automated tests
+
+Tests are run using [pytest](https://pytest.org)). For faster test runs, try adding `--no-cov` to disable coverage reporting and/or `-n auto` to run multiple tests in parallel.
 
 ## API
 The API documentation is available at the `/api/schema/swagger-ui/` endpoint.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ disallow_any_generics = true
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "contentrepo.settings.test"
-addopts = "--cov -n auto"
+addopts = "--cov"
 filterwarnings = [
     # We can't do anything about these warnings until upstream updates.
     "ignore::django.utils.deprecation.RemovedInDjango50Warning:modelcluster.models:28",


### PR DESCRIPTION
## Purpose
Using xdist affects test output, and on some systems the speedup isn't significant. Since there's no easy way to disable it, we leave it off by default and document how to use it in the README.