### PR TITLE
Skip missing related pages during export

### DIFF
--- a/home/export_content_pages.py
+++ b/home/export_content_pages.py
@@ -242,7 +242,10 @@ class ContentExporter:
 
     @staticmethod
     def _related_pages(page: Page) -> list[str]:
-        return [rp.value.slug for rp in page.related_pages]
+        # Ideally, all related page links would be removed when the page they
+        # link to is deleted. We don't currently do that, so for now we just
+        # make sure that we skip such links during export.
+        return [rp.value.slug for rp in page.related_pages if rp.value is not None]
 
     @staticmethod
     def _comma_sep_qs(unformatted_query: PageQuerySet) -> str:

--- a/home/export_content_pages.py
+++ b/home/export_content_pages.py
@@ -372,4 +372,4 @@ def _set_xlsx_styles(wb: Workbook, sheet: Worksheet) -> None:
             cell.font = general_font
             alignment = copy.copy(cell.alignment)
             alignment.wrapText = True
-            cell.alignment = alignment
+            cell.alignment = alignment  # type: ignore # Broken typeshed update, maybe?

--- a/home/tests/page_builder.py
+++ b/home/tests/page_builder.py
@@ -273,6 +273,10 @@ class PageBuilder(Generic[TPage]):
         page: ContentPage, related_pages: Iterable[Page], publish: bool = True
     ) -> ContentPage:
         for related_page in related_pages:
+            # If we don't fetch all existing related pages before adding new
+            # ones, we get an inexplicable TypeError deep in the bowels of
+            # wagtail/blocks/stream_block.py. Good going, wagtail.
+            list(page.related_pages)
             page.related_pages.append(("related_page", related_page))
         rev = page.save_revision()
         if publish:


### PR DESCRIPTION
## Purpose
Currently, export fails if a related page doesn't exist.