### PR TITLE
Make translation keys optional in imports for the default locale

### DIFF
--- a/home/tests/no-translation-key-cp.csv
+++ b/home/tests/no-translation-key-cp.csv
@@ -1,0 +1,5 @@
+structure,message,page_id,slug,parent,web_title,web_subtitle,web_body,whatsapp_title,whatsapp_body,whatsapp_template_name,whatsapp_template_category,example_values,variation_title,variation_body,messenger_title,messenger_body,viber_title,viber_body,translation_tag,tags,quick_replies,triggers,locale,next_prompt,buttons,image_link,doc_link,media_link,related_pages
+Menu 1,0,659,ma_import-export,,MA_import export,,,,,,,,,,,,,,38a22433-e474-4f5a-b06b-7367d1a7f664,,,,English,,,,,,
+Sub 1.1,1,660,locale-import,MA_import export,Locale import,,,import per locale,this is the english message..edit,,UTILITY,,,,,,,,9aab62ab-caf7-4606-b9bf-ac3148309319,,,,English,,[],,,,
+Menu 1,0,1297,ma_import-export,,MA_import export,,,,,,,,,,,,,,38a22433-e474-4f5a-b06b-7367d1a7f664,,,,Portuguese,,,,,,
+Sub 1.1,1,1298,locale-import,MA_import export,Locale import,,,import per locale,this is the Portuguese message....edit,,UTILITY,,,,,,,,,,,,Portuguese,,[],,,,

--- a/home/tests/no-translation-key-cpi.csv
+++ b/home/tests/no-translation-key-cpi.csv
@@ -1,0 +1,5 @@
+structure,message,page_id,slug,parent,web_title,web_subtitle,web_body,whatsapp_title,whatsapp_body,whatsapp_template_name,whatsapp_template_category,example_values,variation_title,variation_body,messenger_title,messenger_body,viber_title,viber_body,translation_tag,tags,quick_replies,triggers,locale,next_prompt,buttons,image_link,doc_link,media_link,related_pages
+Menu 1,0,659,ma_import-export,,MA_import export,,,,,,,,,,,,,,38a22433-e474-4f5a-b06b-7367d1a7f664,,,,English,,,,,,
+Sub 1.1,1,660,locale-import,MA_import export,Locale import,,,import per locale,this is the english message..edit,,UTILITY,,,,,,,,9aab62ab-caf7-4606-b9bf-ac3148309319,,,,English,,[],,,,
+Menu 1,0,1297,ma_import-export,,MA_import export,,,,,,,,,,,,,,,,,,Portuguese,,,,,,
+Sub 1.1,1,1298,locale-import,MA_import export,Locale import,,,import per locale,this is the Portuguese message....edit,,UTILITY,,,,,,,,9aab62ab-caf7-4606-b9bf-ac3148309319,,,,Portuguese,,[],,,,

--- a/home/tests/no-translation-key-default.csv
+++ b/home/tests/no-translation-key-default.csv
@@ -1,0 +1,3 @@
+structure,message,page_id,slug,parent,web_title,web_subtitle,web_body,whatsapp_title,whatsapp_body,whatsapp_template_name,whatsapp_template_category,example_values,variation_title,variation_body,messenger_title,messenger_body,viber_title,viber_body,translation_tag,tags,quick_replies,triggers,locale,next_prompt,buttons,image_link,doc_link,media_link,related_pages
+Menu 1,0,659,ma_import-export,,MA_import export,,,,,,,,,,,,,,,,,,English,,,,,,
+Sub 1.1,1,660,locale-import,MA_import export,Locale import,,,import per locale,this is the english message..edit,,UTILITY,,,,,,,,,,,,English,,[],,,,


### PR DESCRIPTION
## Purpose
We want to be able to import new content without having to generate translation key uuids offline. However, translations must use the same uuids as the pages they're translated from. Allowing empty translation keys for the default locale supports the first case without compromising the second.

## Approach
When building pages, we set the translation key if it's non-empty or if the page in question has a non-default locale. This means an empty translation key for a non-default locale will trigger a validation error, but for the default locale we'll get one generated by wagtail.