### PR TITLE
Add empty value on content import form

### DIFF
--- a/home/forms.py
+++ b/home/forms.py
@@ -12,7 +12,9 @@ class UploadContentFileForm(UploadFileForm):
     YES_NO = ((False, "No"), (True, "Yes"))
     purge = forms.ChoiceField(choices=YES_NO)
     locale = forms.ModelChoiceField(
-        queryset=Locale.objects.all(), empty_label="Select Locale"
+        queryset=Locale.objects.all(),
+        empty_label="Import all languages",
+        required=False,
     )
 
 

--- a/home/tests/test_forms.py
+++ b/home/tests/test_forms.py
@@ -1,0 +1,29 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from home.forms import UploadContentFileForm
+
+
+class TestUploadContentFileForm:
+    @pytest.mark.django_db
+    def test_empty_locale_label(self):
+        """
+        The label for the empty locale option should be Import all languages
+        """
+        assert "Import all languages" in UploadContentFileForm().render()
+
+    def test_default_locale(self):
+        """
+        Not supplying a locale should give a default "None" value, which the importer
+        interprets as we should import all locales found in the file
+        """
+        file = SimpleUploadedFile(
+            name="test.csv", content=b"foo,bar", content_type="text/csv"
+        )
+        form = UploadContentFileForm(
+            files={"file": file},
+            data={"file_type": "CSV", "purge": "False", "locale": ""},
+        )
+
+        assert form.errors == {}
+        assert form.cleaned_data["locale"] is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ exclude = [  # Regexes.
     '^home/tests/test_(management|management_related_tag|models)\.py',
     '^home/tests/test_(unique_slug_hook|views|wagtail_hooks)\.py',
     '^home/tests/test_(whatsapp|whatsapp_template_name_migration)\.py',
+    '^home/tests/test_(forms)\.py',
 ]
 files = "."
 follow_imports = "skip"


### PR DESCRIPTION
## Purpose
We want the user to be able to import all languages present in an import file, all in one go.

## Approach
The content importer already supports this. If it receives a "None" value for the locale, then it imports all locales present in the import file.

This PR allows the locale field in the form to be empty, which will allow us to send a "None" value for the locale to the importer. It also adds a label that makes it clear to the user that leaving the dropdown in the "empty" position will result in the importer importing all locales present in the file.

