### PR TITLE
Import error propagation

### DIFF
--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -297,7 +297,6 @@ class ContentImporter:
             page.enable_whatsapp = True
             buttons = []
             for button in row.buttons:
-                print(button)
                 if button["type"] == "next_message":
                     buttons.append(
                         {
@@ -431,7 +430,16 @@ class ShadowContentPage:
         page = ContentPage.objects.get(slug=self.slug, locale=self.locale)
         related_pages = []
         for related_page_slug in self.related_pages:
-            related_page = Page.objects.get(slug=related_page_slug, locale=self.locale)
+            try:
+                related_page = Page.objects.get(
+                    slug=related_page_slug, locale=self.locale
+                )
+            except Page.DoesNotExist:
+                raise ImportException(
+                    f"Cannot find related page with slug {related_page_slug} and "
+                    f"locale {self.locale}",
+                    self.row_num,
+                )
             related_pages.append(("related_page", related_page))
         page.related_pages = related_pages
         page.save_revision().publish()

--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -31,11 +31,13 @@ from home.models import (
 
 PageId = tuple[str, Locale]
 
+
 class ImportException(Exception):
     """
     Base exception for all import related issues.
     """
-    def __init__(self, message: str, row_num: int | None=None):
+
+    def __init__(self, message: str, row_num: int | None = None):
         self.row_num = row_num
         self.message = message
         super().__init__()
@@ -72,7 +74,9 @@ class ContentImporter:
             if not codes:
                 raise ImportException(f"Language not found: {langname}")
             if len(codes) > 1:
-                raise ImportException(f"Multiple codes for language: {langname} -> {codes}")
+                raise ImportException(
+                    f"Multiple codes for language: {langname} -> {codes}"
+                )
             self.locale_map[langname] = Locale.objects.get(language_code=codes[0])
         return self.locale_map[langname]
 

--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -127,8 +127,8 @@ class ContentImporter:
                     parent = Page.objects.get(title=page.parent, locale=page.locale)
                 except Page.DoesNotExist:
                     raise ImportException(
-                        f"Cannot find parent page with title {page.parent} and locale "
-                        f"{page.locale}",
+                        f"Cannot find parent page with title '{page.parent}' and "
+                        f"locale '{page.locale}'",
                         page.row_num,
                     )
                 except Page.MultipleObjectsReturned:
@@ -136,8 +136,8 @@ class ContentImporter:
                         title=page.parent, locale=page.locale
                     ).values_list("slug", flat=True)
                     raise ImportException(
-                        f"Multiple pages with title {page.parent} and locale "
-                        f"{page.locale} for parent page: {list(parents)}",
+                        f"Multiple pages with title '{page.parent}' and locale "
+                        f"'{page.locale}' for parent page: {list(parents)}",
                         page.row_num,
                     )
             else:
@@ -166,9 +166,9 @@ class ContentImporter:
                     except Page.DoesNotExist:
                         row = self.shadow_pages[(slug, locale)]
                         raise ImportException(
-                            f"No pages found with slug {button['slug']} and locale "
-                            f"{locale} for go_to_page button {button['title']} on page "
-                            f"{slug}",
+                            f"No pages found with slug '{button['slug']}' and locale "
+                            f"'{locale}' for go_to_page button '{button['title']}' on "
+                            f"page '{slug}'",
                             row.row_num,
                         )
                     page.whatsapp_body[message_index].value["buttons"].append(
@@ -436,8 +436,8 @@ class ShadowContentPage:
                 )
             except Page.DoesNotExist:
                 raise ImportException(
-                    f"Cannot find related page with slug {related_page_slug} and "
-                    f"locale {self.locale}",
+                    f"Cannot find related page with slug '{related_page_slug}' and "
+                    f"locale '{self.locale}'",
                     self.row_num,
                 )
             related_pages.append(("related_page", related_page))

--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -164,10 +164,12 @@ class ContentImporter:
                             slug=button["slug"], locale=locale
                         )
                     except Page.DoesNotExist:
+                        row = self.shadow_pages[(slug, locale)]
                         raise ImportException(
                             f"No pages found with slug {button['slug']} and locale "
                             f"{locale} for go_to_page button {button['title']} on page "
-                            f"{slug}"
+                            f"{slug}",
+                            row.row_num,
                         )
                     page.whatsapp_body[message_index].value["buttons"].append(
                         ("go_to_page", {"page": related_page, "title": title})
@@ -295,6 +297,7 @@ class ContentImporter:
             page.enable_whatsapp = True
             buttons = []
             for button in row.buttons:
+                print(button)
                 if button["type"] == "next_message":
                     buttons.append(
                         {

--- a/home/tests/invalid-locale-name.csv
+++ b/home/tests/invalid-locale-name.csv
@@ -1,0 +1,2 @@
+structure,message,page_id,slug,parent,web_title,web_subtitle,web_body,whatsapp_title,whatsapp_body,whatsapp_template_name,whatsapp_template_category,example_values,variation_title,variation_body,messenger_title,messenger_body,viber_title,viber_body,translation_tag,tags,quick_replies,triggers,locale,next_prompt,buttons,image_link,doc_link,media_link,related_pages
+Menu 1,0,659,ma_import-export,,MA_import export,,,,,,,,,,,,,,38a22433-e474-4f5a-b06b-7367d1a7f664,,,,NotEnglish,,,,,,

--- a/home/tests/missing-gotopage.csv
+++ b/home/tests/missing-gotopage.csv
@@ -1,0 +1,2 @@
+structure,message,page_id,slug,parent,web_title,web_subtitle,web_body,whatsapp_title,whatsapp_body,whatsapp_template_name,whatsapp_template_category,example_values,variation_title,variation_body,messenger_title,messenger_body,viber_title,viber_body,translation_tag,tags,quick_replies,triggers,locale,next_prompt,buttons,image_link,doc_link,media_link,related_pages
+Menu 1,0,659,ma_import-export,,MA_import export,,,Missing,GoToPage,,,,,,,,,,38a22433-e474-4f5a-b06b-7367d1a7f664,,,,English,,"[{""type"":""go_to_page"",""title"":""Missing"",""slug"":""missing""}]",,,,

--- a/home/tests/missing-parent.csv
+++ b/home/tests/missing-parent.csv
@@ -1,0 +1,2 @@
+structure,message,page_id,slug,parent,web_title,web_subtitle,web_body,whatsapp_title,whatsapp_body,whatsapp_template_name,whatsapp_template_category,example_values,variation_title,variation_body,messenger_title,messenger_body,viber_title,viber_body,translation_tag,tags,quick_replies,triggers,locale,next_prompt,buttons,image_link,doc_link,media_link,related_pages
+Menu 1,0,659,ma_import-export,missing-parent,MA_import export,,,,,,,,,,,,,,38a22433-e474-4f5a-b06b-7367d1a7f664,,,,English,,,,,,

--- a/home/tests/missing-related-page.csv
+++ b/home/tests/missing-related-page.csv
@@ -1,0 +1,2 @@
+structure,message,page_id,slug,parent,web_title,web_subtitle,web_body,whatsapp_title,whatsapp_body,whatsapp_template_name,whatsapp_template_category,example_values,variation_title,variation_body,messenger_title,messenger_body,viber_title,viber_body,translation_tag,tags,quick_replies,triggers,locale,next_prompt,buttons,image_link,doc_link,media_link,related_pages
+Menu 1,0,659,ma_import-export,,MA_import export,,Test body,,,,,,,,,,,,38a22433-e474-4f5a-b06b-7367d1a7f664,,,,English,,,,,,missing related

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -858,6 +858,21 @@ class TestImportExport:
             "page: ['missing-parent1', 'missing-parent2']"
         )
 
+    def test_go_to_page_button_missing_page(self, newcsv_impexp: ImportExport) -> None:
+        """
+        Go to page buttons in the import file link to other pages using the slug. But
+        if no page with that slug exists, then we should give the user an error message
+        that tells them where and how to fix it.
+        """
+        with pytest.raises(ImportException) as e:
+            newcsv_impexp.import_file("missing-gotopage.csv")
+        assert e.value.row_num == 2
+        assert (
+            e.value.message
+            == "No pages found with slug missing and locale English for go_to_page "
+            "button Missing on page ma_import-export"
+        )
+
 
 # "old-xlsx" has at least three bugs, so we don't bother testing it.
 @pytest.fixture(params=["old-csv", "new-csv", "new-xlsx"])

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -835,7 +835,8 @@ class TestImportExport:
         assert e.value.row_num == 2
         assert (
             e.value.message
-            == "Cannot find parent page with title missing-parent and locale English"
+            == "Cannot find parent page with title 'missing-parent' and locale "
+            "'English'"
         )
 
     def test_multiple_parents(self, newcsv_impexp: ImportExport) -> None:
@@ -854,8 +855,8 @@ class TestImportExport:
         assert e.value.row_num == 2
         assert (
             e.value.message
-            == "Multiple pages with title missing-parent and locale English for parent "
-            "page: ['missing-parent1', 'missing-parent2']"
+            == "Multiple pages with title 'missing-parent' and locale 'English' for "
+            "parent page: ['missing-parent1', 'missing-parent2']"
         )
 
     def test_go_to_page_button_missing_page(self, newcsv_impexp: ImportExport) -> None:
@@ -869,8 +870,8 @@ class TestImportExport:
         assert e.value.row_num == 2
         assert (
             e.value.message
-            == "No pages found with slug missing and locale English for go_to_page "
-            "button Missing on page ma_import-export"
+            == "No pages found with slug 'missing' and locale 'English' for go_to_page "
+            "button 'Missing' on page 'ma_import-export'"
         )
 
     def test_missing_related_pages(self, newcsv_impexp: ImportExport) -> None:
@@ -884,7 +885,8 @@ class TestImportExport:
         assert e.value.row_num == 2
         assert (
             e.value.message
-            == "Cannot find related page with slug missing related and locale English"
+            == "Cannot find related page with slug 'missing related' and locale "
+            "'English'"
         )
 
 

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -13,7 +13,6 @@ import pytest
 from django.core import serializers  # type: ignore
 from django.core.exceptions import ValidationError  # type: ignore
 from django.core.files.images import ImageFile  # type: ignore
-from django.test import override_settings  # type: ignore
 from openpyxl import load_workbook
 from pytest_django.fixtures import SettingsWrapper
 from wagtail.images.models import Image  # type: ignore
@@ -805,15 +804,17 @@ class TestImportExport:
         assert e.value.row_num == 2
         assert e.value.message == "Language not found: NotEnglish"
 
-    @override_settings(LANGUAGES=[("en1", "NotEnglish"), ("en2", "NotEnglish")])
-    @override_settings(
-        WAGTAIL_CONTENT_LANGUAGES=[("en1", "NotEnglish"), ("en2", "NotEnglish")]
-    )
-    def test_multiple_locales_for_name(self, newcsv_impexp: ImportExport) -> None:
+    def test_multiple_locales_for_name(
+        self, newcsv_impexp: ImportExport, settings: SettingsWrapper
+    ) -> None:
         """
         Importing pages with locale names that represent multiple locales should raise
         an error that results in an error message that gets sent back to the user
         """
+        settings.WAGTAIL_CONTENT_LANGUAGES = settings.LANGUAGES = [
+            ("en1", "NotEnglish"),
+            ("en2", "NotEnglish"),
+        ]
         with pytest.raises(ImportException) as e:
             newcsv_impexp.import_file("invalid-locale-name.csv")
 

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -873,6 +873,20 @@ class TestImportExport:
             "button Missing on page ma_import-export"
         )
 
+    def test_missing_related_pages(self, newcsv_impexp: ImportExport) -> None:
+        """
+        Related pages are listed as comma separated slugs in imported files. If there
+        is a slug listed that we cannot find the page for, then we should show the
+        user an error with information about the missing page.
+        """
+        with pytest.raises(ImportException) as e:
+            newcsv_impexp.import_file("missing-related-page.csv")
+        assert e.value.row_num == 2
+        assert (
+            e.value.message
+            == "Cannot find related page with slug missing related and locale English"
+        )
+
 
 # "old-xlsx" has at least three bugs, so we don't bother testing it.
 @pytest.fixture(params=["old-csv", "new-csv", "new-xlsx"])

--- a/home/views.py
+++ b/home/views.py
@@ -27,6 +27,7 @@ from wagtail.admin.widgets import AdminDateInput
 from wagtail.contrib.modeladmin.views import IndexView
 
 from .content_import_export import import_content, import_ordered_sets
+from .import_content_pages import ImportException
 from .forms import UploadContentFileForm, UploadOrderedContentSetFileForm
 from .mixins import SpreadsheetExportMixin
 from .models import ContentPage, ContentPageRating, OrderedContentSet, PageView
@@ -146,6 +147,8 @@ class ContentUploadThread(UploadThread):
             import_content(
                 self.file, self.file_type, self.progress_queue, self.purge, self.locale
             )
+        except ImportException as e:
+            self.result_queue.put((messages.ERROR, f"Content import failed on row {e.row_num}: {e.message}"))
         except Exception:
             self.result_queue.put((messages.ERROR, "Content import failed"))
             logger.exception("Content import failed")

--- a/home/views.py
+++ b/home/views.py
@@ -27,8 +27,8 @@ from wagtail.admin.widgets import AdminDateInput
 from wagtail.contrib.modeladmin.views import IndexView
 
 from .content_import_export import import_content, import_ordered_sets
-from .import_content_pages import ImportException
 from .forms import UploadContentFileForm, UploadOrderedContentSetFileForm
+from .import_content_pages import ImportException
 from .mixins import SpreadsheetExportMixin
 from .models import ContentPage, ContentPageRating, OrderedContentSet, PageView
 from .serializers import ContentPageRatingSerializer, PageViewSerializer
@@ -148,7 +148,12 @@ class ContentUploadThread(UploadThread):
                 self.file, self.file_type, self.progress_queue, self.purge, self.locale
             )
         except ImportException as e:
-            self.result_queue.put((messages.ERROR, f"Content import failed on row {e.row_num}: {e.message}"))
+            self.result_queue.put(
+                (
+                    messages.ERROR,
+                    f"Content import failed on row {e.row_num}: {e.message}",
+                )
+            )
         except Exception:
             self.result_queue.put((messages.ERROR, "Content import failed"))
             logger.exception("Content import failed")


### PR DESCRIPTION
## Purpose
If there are any issues during import, currently the admin user gets a generic error, we roll back, and log the error message.

Someone needs to then go and investigate the error message, figure out what went wrong with the import, and fix it.

Often there are issues with the import file that are not an issue with the import code. In those cases, we want to rather show an error message to the admin user with enough information for them to fix the import file, rather than logging an error.

## Approach
We create a new exception, ImportException, and if we have an exception of this error type, we rather put the error information in the error message sent back to the admin user, instead of using the generic error and logging the exception. This will hopefully give the admin user enough information to fix the issue in the import file, and try again.

![image](https://github.com/praekeltfoundation/contentrepo/assets/8234653/f4fb0c2a-f492-48a2-83e7-8fcadefedc22)

