### PR TITLE
Mnch 985 contentrepo whatsapp template

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ createdb contentrepo
 
 ### Automated tests
 
-Tests are run using [pytest](https://pytest.org)). For faster test runs, try adding `--no-cov` to disable coverage reporting and/or `-n auto` to run multiple tests in parallel.
+Tests are run using [pytest](https://pytest.org). For faster test runs, try adding `--no-cov` to disable coverage reporting and/or `-n auto` to run multiple tests in parallel.
 
 ## API
 The API documentation is available at the `/api/schema/swagger-ui/` endpoint.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ This can work for mac and (possibly Windows) by setting the environment variable
 
 Run the following in a virtual environment
 ```bash
-pip install -e .[dev]
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
 createdb contentrepo
 ./manage.py migrate
 ./manage.py createsuperuser

--- a/home/models.py
+++ b/home/models.py
@@ -605,9 +605,7 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
 
     @property
     def whatsapp_template_prefix(self):
-        if self.whatsapp_title:
-            self.whatsapp_title = self.whatsapp_title.lower()
-        return self.whatsapp_title.replace(" ", "_")
+        return self.whatsapp_title.lower().replace(" ", "_")
 
     @property
     def whatsapp_template_body(self):

--- a/home/models.py
+++ b/home/models.py
@@ -605,6 +605,8 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
 
     @property
     def whatsapp_template_prefix(self):
+        if self.whatsapp_title:
+            self.whatsapp_title = self.whatsapp_title.lower()
         return self.whatsapp_title.replace(" ", "_")
 
     @property

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -58,7 +58,7 @@ class ContentPageTests(TestCase):
     def test_template_create_on_save(self, mock_create_whatsapp_template):
         page = create_page(is_whatsapp_template=True)
         mock_create_whatsapp_template.assert_called_with(
-            f"WA_Title_{page.get_latest_revision().id}",
+            f"wa_title_{page.get_latest_revision().id}",
             "Test WhatsApp Message 1",
             "UTILITY",
             [],
@@ -71,7 +71,7 @@ class ContentPageTests(TestCase):
     def test_template_create_with_buttons_on_save(self, mock_create_whatsapp_template):
         page = create_page(is_whatsapp_template=True, has_quick_replies=True)
         mock_create_whatsapp_template.assert_called_with(
-            f"WA_Title_{page.get_latest_revision().id}",
+            f"wa_title_{page.get_latest_revision().id}",
             "Test WhatsApp Message 1",
             "UTILITY",
             ["button 1", "button 2"],
@@ -86,7 +86,7 @@ class ContentPageTests(TestCase):
     ):
         page = create_page(is_whatsapp_template=True, add_example_values=True)
         mock_create_whatsapp_template.assert_called_with(
-            f"WA_Title_{page.get_latest_revision().id}",
+            f"wa_title_{page.get_latest_revision().id}",
             "Test WhatsApp Message with two variables, {{1}} and {{2}}",
             "UTILITY",
             [],
@@ -103,7 +103,7 @@ class ContentPageTests(TestCase):
         """
         page = create_page(is_whatsapp_template=True, has_quick_replies=True)
         mock_create_whatsapp_template.assert_called_once_with(
-            f"WA_Title_{page.get_latest_revision().pk}",
+            f"wa_title_{page.get_latest_revision().pk}",
             "Test WhatsApp Message 1",
             "UTILITY",
             ["button 1", "button 2"],
@@ -116,7 +116,7 @@ class ContentPageTests(TestCase):
         revision = page.save_revision()
         revision.publish()
 
-        expected_title = f"WA_Title_{page.get_latest_revision().pk}"
+        expected_title = f"wa_title_{page.get_latest_revision().pk}"
         mock_create_whatsapp_template.assert_called_once_with(
             expected_title,
             "Test WhatsApp Message 2",
@@ -138,7 +138,7 @@ class ContentPageTests(TestCase):
         page = create_page(is_whatsapp_template=True, has_quick_replies=True)
         page.get_latest_revision().publish()
         page.refresh_from_db()
-        expected_template_name = f"WA_Title_{page.get_latest_revision().pk}"
+        expected_template_name = f"wa_title_{page.get_latest_revision().pk}"
         mock_create_whatsapp_template.assert_called_once_with(
             expected_template_name,
             "Test WhatsApp Message 1",
@@ -172,7 +172,7 @@ class ContentPageTests(TestCase):
         page.save_revision().publish()
 
         page.refresh_from_db()
-        expected_template_name = f"WA_Title_{page.get_latest_revision().pk}"
+        expected_template_name = f"wa_title_{page.get_latest_revision().pk}"
         self.assertEqual(page.whatsapp_template_name, expected_template_name)
         mock_create_whatsapp_template.assert_called_once_with(
             expected_template_name,
@@ -205,7 +205,7 @@ class ContentPageTests(TestCase):
         page.is_whatsapp_template = True
         page.save_revision()
 
-        expected_template_name = f"WA_Title_{page.get_latest_revision().pk}"
+        expected_template_name = f"wa_title_{page.get_latest_revision().pk}"
         mock_create_whatsapp_template.assert_called_once_with(
             expected_template_name,
             "Test WhatsApp Message 1",

--- a/home/tests/test_whatsapp.py
+++ b/home/tests/test_whatsapp.py
@@ -23,7 +23,7 @@ class TestWhatsApp:
         url = "http://whatsapp/graph/v14.0/27121231234/message_templates"
         responses.add(responses.POST, url, json={})
 
-        create_whatsapp_template("Test-Template", "Test Body", "UTILITY")
+        create_whatsapp_template("test-template", "Test Body", "UTILITY")
 
         request = responses.calls[0].request
 
@@ -55,7 +55,7 @@ class TestWhatsApp:
         responses.add(responses.POST, url, json={})
 
         create_whatsapp_template(
-            "Test-Template",
+            "test-template",
             "Hi {{1}}. You are testing as a {{2}}",
             "UTILITY",
             [],
@@ -88,7 +88,7 @@ class TestWhatsApp:
         responses.add(responses.POST, url, json={})
 
         create_whatsapp_template(
-            "Test-Template",
+            "test-template",
             "Test Body",
             "UTILITY",
             ["Test button1", "test button2"],
@@ -137,7 +137,7 @@ class TestWhatsApp:
         responses.add(responses.POST, template_url, json={})
 
         create_whatsapp_template(
-            "Test-Template", "Test Body", "UTILITY", [], saved_image.id
+            "test-template", "Test Body", "UTILITY", [], saved_image.id
         )
 
         mock_get_session_data = {

--- a/home/whatsapp.py
+++ b/home/whatsapp.py
@@ -50,7 +50,7 @@ def create_whatsapp_template(
 
     data = {
         "category": category,
-        "name": name.lower(),
+        "name": name,
         "language": "en_US",
         "components": components,
     }


### PR DESCRIPTION
## Purpose
_Describe the problem or feature in addition to a link to the issues._
Template was store with uppercase and throw an error when they try to retrieve it as template names are stored with lower case.

## Approach
_How does this change address the problem?_
Convert whatsapp template name to lower case before we store it.

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage_

Create a whatsapp template locally and modify unittests

_Links to blog posts, patterns, libraries or addons used to solve this problem_
None

#### Blog Posts
- [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.
