### PR TITLE
confidance threshold to word embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Please make sure to update tests as appropriate.
 
 ## Content Embeddings
 if you want to generate content content embeddings, please make sure you define LOAD_TRANSFORMER_MODEL in your environment and set it to True
+NB: this causes the model to be loaded into memory and can significantly increase resource requirements
 
 ## License
 [MIT](https://choosealicense.com/licenses/mit/)

--- a/README.md
+++ b/README.md
@@ -128,5 +128,8 @@ Pull requests are welcome. For major changes, please open an issue first to disc
 
 Please make sure to update tests as appropriate.
 
+## Content Embeddings
+if you want to generate content content embeddings, please make sure you define LOAD_TRANSFORMER_MODEL in your environment and set it to True
+
 ## License
 [MIT](https://choosealicense.com/licenses/mit/)

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -132,7 +132,7 @@ class TestContentPageAPI:
         assert content["count"] == 0
         # it should not return search term matching pages if they are unpublished
         page1.unpublish()
-        response = uclient.get("/api/v2/pages/?s=#(&whatsapp=true")
+        response = uclient.get("/api/v2/pages/?s=help(&whatsapp=true")
         content = json.loads(response.content)
         assert content["count"] == 0
 

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -122,7 +122,7 @@ class TestContentPageAPI:
         content = json.loads(response.content)
         assert content["count"] == 1
         # it should return 0 pages for meaningless search term
-        response = uclient.get("/api/v2/pages/?s=#(&whatsapp=true")
+        response = uclient.get("/api/v2/pages/?s=%23&whatsapp=true")
         content = json.loads(response.content)
         assert content["count"] == 0
         # it should return 0 pages for correct search term if no platform is provided

--- a/home/word_embedding.py
+++ b/home/word_embedding.py
@@ -31,7 +31,7 @@ def retrieve_top_n_content_pieces(
         )  # Replace with your cosine similarity calculation
         documents_retrieved.append((page.pk, page.title, page.body, similarity_score))
     documents_retrieved = sorted(documents_retrieved, key=lambda x: x[3], reverse=True)
-    content_retrieved = [doc[0] for doc in documents_retrieved[0:n]]
+    content_retrieved = [doc[0] for doc in documents_retrieved[0:n] if doc[3] >= 0.25]
     return content_retrieved
 
 
@@ -70,7 +70,7 @@ def preprocess_content_for_embedding(content):
         extract = " ".join(extract)
         content = content.replace(url, extract)
     content = (
-        "".join(content.split("*", 2)[2:])
+        content
         .replace("\n\n", " ")
         .replace("\n", " ")
         .replace("  ", " ")
@@ -78,8 +78,7 @@ def preprocess_content_for_embedding(content):
     )  # Remove content piece title
     if len(content) < 2:
         return content
-    if content[0] == " ":  # Remove space trailing content title
-        content = content[1:]
+    content = content.lstrip().rstrip()  # Remove spaces leading/trailing content
     emoji_pattern = re.compile(
         "["
         "\U0001F600-\U0001F64F"  # emoticons


### PR DESCRIPTION
- added confidence threshold for word embedding results
- Improved word embedding preprocessing
- Updated read me for embedding generation

## Purpose
The aaq search was returning results even in the cases when the user has entered meaningless invalid text
https://praekelt.leankit.com/card/31512186572175

## Approach
Added a confidence threshold so that we can filter out any returned results that have a similarity score of less than 25%

#### Open Questions and Pre-Merge TODOs

## Learning
From analysing how different search inputs compare to the results, in terms of similarity score, 25% similarity gave a balance between giving back relevant answers and filtering out completely unrelated responses


#### Blog Posts
