### PR TITLE
Add a test for migrations

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -38,7 +38,7 @@ from wagtail.admin.panels import (  # isort:skip
     MultiFieldPanel,
     ObjectList,
     TabbedInterface,
-    TitleFieldPanel
+    TitleFieldPanel,
 )
 import logging
 

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -1,5 +1,5 @@
-from unittest import mock
 from io import StringIO
+from unittest import mock
 
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
@@ -323,10 +323,15 @@ class ContentPageTests(TestCase):
 
         self.assertRaises(ValidationError)
         self.assertEqual(e.exception.message, "Failed to submit template")
+
     def test_for_missing_migrations(self):
         output = StringIO()
         call_command("makemigrations", no_input=True, dry_run=True, stdout=output)
-        self.assertEqual(output.getvalue().strip(), "No changes detected", "There are missing migrations:\n %s" % output.getvalue())
+        self.assertEqual(
+            output.getvalue().strip(),
+            "No changes detected",
+            "There are missing migrations:\n %s" % output.getvalue(),
+        )
 
 
 class WhatsappBlockTests(TestCase):

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -1,6 +1,8 @@
 from unittest import mock
+from io import StringIO
 
 from django.core.exceptions import ValidationError
+from django.core.management import call_command
 from django.test import TestCase, override_settings
 from requests import HTTPError
 from wagtail.blocks import StructBlockValidationError
@@ -321,6 +323,10 @@ class ContentPageTests(TestCase):
 
         self.assertRaises(ValidationError)
         self.assertEqual(e.exception.message, "Failed to submit template")
+    def test_for_missing_migrations(self):
+        output = StringIO()
+        call_command("makemigrations", no_input=True, dry_run=True, stdout=output)
+        self.assertEqual(output.getvalue().strip(), "No changes detected", "There are missing migrations:\n %s" % output.getvalue())
 
 
 class WhatsappBlockTests(TestCase):


### PR DESCRIPTION
## Purpose
It's easy to make changes to a model and then forget to add a migration. [Ticket](https://praekelt.leankit.com/card/31512189556878)

## Approach
This adds a test that will fail if it's necessary to create a migration

#### Open Questions and Pre-Merge TODOs
- [x] The tests are failing because it's picking up a missing wagtailcore migration. Running makemigrations, and migrate on local solved the issue, but the migration is created in site-packages. Maybe we need a makemigrations and migrate step before everything?

