### PR TITLE
Import test

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -7,7 +7,6 @@ from django.db import models
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.forms import CheckboxSelectMultiple
-from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
@@ -39,6 +38,7 @@ from wagtail.admin.panels import (  # isort:skip
     MultiFieldPanel,
     ObjectList,
     TabbedInterface,
+    TitleFieldPanel,
 )
 import logging
 
@@ -65,17 +65,6 @@ class UniqueSlugMixin:
             suffix += 1
             candidate_slug = f"{slug}-{suffix}"
         return candidate_slug
-
-    def full_clean(self, *args, **kwargs):
-        # Autogenerate slug if not present
-        if not self.slug:
-            allow_unicode = getattr(settings, "WAGTAIL_ALLOW_UNICODE_SLUGS", True)
-            base_slug = slugify(self.title, allow_unicode=allow_unicode)
-
-            if base_slug:
-                self.slug = self.get_unique_slug(base_slug)
-
-        super().full_clean(*args, **kwargs)
 
     def clean(self):
         super().clean()
@@ -483,7 +472,7 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
     web_panels = [
         MultiFieldPanel(
             [
-                FieldPanel("title"),
+                TitleFieldPanel("title"),
                 FieldPanel("subtitle"),
                 FieldPanel("body"),
                 FieldPanel("include_in_footer"),
@@ -926,10 +915,6 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
             raise ValidationError(errors)
 
         return result
-
-
-# Allow slug to be blank in forms, we fill it in in full_clean
-Page._meta.get_field("slug").blank = True
 
 
 @receiver(pre_save, sender=ContentPage)

--- a/home/tests/content_page_required_fields.csv
+++ b/home/tests/content_page_required_fields.csv
@@ -1,0 +1,2 @@
+message,slug,parent,web_title,locale
+0,Main-menu-field,Main Menu,Main Menu-title,English

--- a/home/tests/required_fields.csv
+++ b/home/tests/required_fields.csv
@@ -1,0 +1,2 @@
+message,slug,parent,web_title,locale
+0,main-menu,,Main Menu,English

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1019,6 +1019,21 @@ class TestImportExport:
             == "Validation error: {'translation_key': ['“BADUUID” is not a valid UUID.']}"
         )
 
+    def test_import_required_fields(self, newcsv_impexp: ImportExport) -> None:
+        """
+        Importing an CSV file with only the required fields shoud not break
+
+        """
+
+        csv_bytes = newcsv_impexp.import_file("required_fields.csv")
+        content = newcsv_impexp.export_content()
+        src, dst = newcsv_impexp.csvs2dicts(csv_bytes, content)
+        allowed_keys = ["message", "slug", "parent", "web_title", "locale"]
+        dst = [{k: v for k, v in item.items() if k in allowed_keys} for item in dst]
+        src = [{k: v for k, v in item.items() if k in allowed_keys} for item in src]
+        assert dst == src
+
+
 
 # "old-xlsx" has at least three bugs, so we don't bother testing it.
 @pytest.fixture(params=["old-csv", "new-csv", "new-xlsx"])

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -1,6 +1,8 @@
+from io import StringIO
 from unittest import mock
 
 from django.core.exceptions import ValidationError
+from django.core.management import call_command
 from django.test import TestCase, override_settings
 from requests import HTTPError
 from wagtail.blocks import StructBlockValidationError
@@ -321,6 +323,15 @@ class ContentPageTests(TestCase):
 
         self.assertRaises(ValidationError)
         self.assertEqual(e.exception.message, "Failed to submit template")
+
+    def test_for_missing_migrations(self):
+        output = StringIO()
+        call_command("makemigrations", no_input=True, dry_run=True, stdout=output)
+        self.assertEqual(
+            output.getvalue().strip(),
+            "No changes detected",
+            "There are missing migrations:\n %s" % output.getvalue(),
+        )
 
 
 class WhatsappBlockTests(TestCase):


### PR DESCRIPTION
## Purpose
We do not have a test that ensures that optional import fields are and will be truly optional

## Approach
There is a test added that imports a CSV with only those required fields populated.

#### Open Questions and Pre-Merge TODOs
When importing a csv with only the required fields present(ie. the columns of the csv), the UI import works. However, when testing that csv, and comparing it with the exported file, the test fails. This is because the exporter will generate all the columns for that file, while the imported csv will only have a few columns. The fix to this is to  test using a csv that has all the fields, but only the required fields are populated. 



