### PR TITLE
Remove partial match

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ For Linux and WSL2 (Windows Subsystem for Linux)
  Creating a docker container with the ports exposed, called `cr_redis`
 `docker run -d -p 6379:6379 --name cr_redis redis`
 
-To then run the docker container,
-`docker run cr_redis`
+To then start the docker container,
+`docker start cr_redis`
 
 This can work for mac and (possibly Windows) by setting the environment variable `CACHE_URL=redis://0.0.0.0:6379/0`
 
@@ -72,13 +72,20 @@ This can work for mac and (possibly Windows) by setting the environment variable
 Local tests run using in-memory sqlite, so postgres isn't required.
 
 For Linux and WSL2 (Windows Subsystem for Linux)
-Creating a docker container that doesnt require a password and matches the setup of the database in settings
+Creating a docker container that doesn't require a password and matches the setup of the database in settings
 `docker run --name cr_postgres -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_USER=postgres -e POSTGRES_DB=contentrepo -d postgres:latest`
 
-To then run the docker container,
-`docker run cr_postgres`
+To then start the docker container,
+`docker start cr_postgres`
 
 This can work for mac and (possibly Windows) by setting the environment variable `DATABASE_URL=postgres://postgres@0.0.0.0/contentrepo`
+
+Then create the DB by entering the cr_postgres container and creating a db, note that the user will need to be changed from root to postgres
+```bash
+docker exec -it cr_postgres bash  
+su - postgres
+createdb contentrepo
+```
 
 ### Wagtail server
 
@@ -87,7 +94,6 @@ Run the following in a virtual environment
 python -m pip install --upgrade pip
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
-createdb contentrepo
 ./manage.py migrate
 ./manage.py createsuperuser
 ./manage.py runserver

--- a/home/models.py
+++ b/home/models.py
@@ -1026,10 +1026,10 @@ class OrderedContentSet(index.Indexed, models.Model):
         blank=True,
     )
     search_fields = [
-        index.SearchField("name", partial_match=True),
-        index.SearchField("get_gender", partial_match=True),
-        index.SearchField("get_age", partial_match=True),
-        index.SearchField("get_relationship", partial_match=True),
+        index.SearchField("name"),
+        index.SearchField("get_gender"),
+        index.SearchField("get_age"),
+        index.SearchField("get_relationship"),
     ]
     pages = StreamField(
         [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ filterwarnings = [
     "ignore::django.utils.deprecation.RemovedInDjango50Warning:modelcluster.models:28",
     "ignore::DeprecationWarning:l18n.translation:17",
     "ignore::DeprecationWarning:wagtail.images.views.serve:1",
+    "ignore::django.utils.deprecation.RemovedInDjango50Warning:home.tests.test_forms:13"
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Purpose
The `partial_match` parameter from the `SearchField` class was dropped in later versions of Wagtail.

## Approach
Upon investigation, the UI changes have accounted for the convenience that `partial_match` added in previous versions. `AutocompleteField` was added to replace the removal of the parameter and takes the same parameters in `SearchField`. 

This can be used later down the line if it is found that the new functionality is not sufficient, however, this does not seem to be the case.


#### Links
- [AutocompleteField in the currently used version of wagtail (5.2)](https://docs.wagtail.org/en/stable/topics/search/indexing.html#index-autocompletefield)
-  [SearchField with partial match in Wagtail 4.0](https://docs.wagtail.org/en/v4.0.4/topics/search/indexing.html#index-searchfield)
