### PR TITLE
Fix issues with Ordered Content Set import / export

### DIFF
--- a/home/content_import_export.py
+++ b/home/content_import_export.py
@@ -46,7 +46,7 @@ def import_ordered_sets(file, filetype, progress_queue, purge=False):
             ordered_set = OrderedContentSet(name=set_name)
 
         ordered_set.profile_fields = []
-        for field in [f.strip() for f in row["Profile Fields"].split(",")]:
+        for field in [f.strip() for f in (row["Profile Fields"] or "").split(",")]:
             if not field or field == "-":
                 continue
             [field_name, field_value] = field.split(":")

--- a/home/models.py
+++ b/home/models.py
@@ -1023,7 +1023,7 @@ class OrderedContentSet(DraftStateMixin, RevisionMixin, index.Indexed, models.Mo
 
     def page(self):
         if self.pages:
-            return [(self._get_field_value(p, "contentpage")) for p in self.pages]
+            return [(self._get_field_value(p, "contentpage", raw=True).slug) for p in self.pages]
         return ["-"]
 
     page.short_description = "Page Slugs"
@@ -1061,10 +1061,10 @@ class OrderedContentSet(DraftStateMixin, RevisionMixin, index.Indexed, models.Mo
 
     num_pages.short_description = "Number of Pages"
 
-    def _get_field_value(self, page: Page, field: str) -> str:
+    def _get_field_value(self, page: Page, field: str, raw: bool = False) -> any:
         try:
             if value := page.value[field]:
-                return f"{value}"
+                return value if raw else f"{value}"
             else:
                 return ""
         except (AttributeError, TypeError):

--- a/home/models.py
+++ b/home/models.py
@@ -1023,7 +1023,10 @@ class OrderedContentSet(DraftStateMixin, RevisionMixin, index.Indexed, models.Mo
 
     def page(self):
         if self.pages:
-            return [(self._get_field_value(p, "contentpage", raw=True).slug) for p in self.pages]
+            return [
+                (self._get_field_value(p, "contentpage", raw=True).slug)
+                for p in self.pages
+            ]
         return ["-"]
 
     page.short_description = "Page Slugs"

--- a/home/tests/import-export-data/ordered_content_no_profile_fields.csv
+++ b/home/tests/import-export-data/ordered_content_no_profile_fields.csv
@@ -1,0 +1,2 @@
+Name,Profile Fields,Page Slugs,Time,Unit,Before Or After,Contact Field
+Test Set,,first_time_user,2,days,before,edd

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1033,7 +1033,9 @@ class TestImportExport:
             ("relationship", "in_a_relationship"),
         ]
 
-    def test_import_ordered_sets_no_profile_fields_csv(self, csv_impexp: ImportExport) -> None:
+    def test_import_ordered_sets_no_profile_fields_csv(
+        self, csv_impexp: ImportExport
+    ) -> None:
         """
         Importing a CSV file with ordered content sets should not break
         """

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1033,6 +1033,27 @@ class TestImportExport:
             ("relationship", "in_a_relationship"),
         ]
 
+    def test_import_ordered_sets_no_profile_fields_csv(self, csv_impexp: ImportExport) -> None:
+        """
+        Importing a CSV file with ordered content sets should not break
+        """
+        csv_impexp.import_file("contentpage_required_fields.csv")
+        content = csv_impexp.read_bytes("ordered_content_no_profile_fields.csv")
+        csv_impexp.import_ordered_sets(content)
+
+        ordered_set = OrderedContentSet.objects.filter(name="Test Set").first()
+
+        assert ordered_set.name == "Test Set"
+        pages = unwagtail(ordered_set.pages)
+        assert len(pages) == 1
+        page = pages[0][1]
+        assert page["contentpage"].slug == "first_time_user"
+        assert page["time"] == "2"
+        assert page["unit"] == "days"
+        assert page["before_or_after"] == "before"
+        assert page["contact_field"] == "edd"
+        assert unwagtail(ordered_set.profile_fields) == []
+
     def test_import_ordered_sets_xlsx(
         self, xlsx_impexp: ImportExport, csv_impexp: ImportExport
     ) -> None:


### PR DESCRIPTION
## Purpose
When importing an export from Ordered Content sets, all the data except Profile fields is being deleted.

## Approach
The export is exporting the slug title, not the slug itself. This PR fixes the export, which then fixes the import.c Additionally another issue is fixed, where the import crashes if there are no profile fields.
