### PR TITLE
added contentpage creation check

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -373,14 +373,16 @@ class MessengerBlock(blocks.StructBlock):
 
 
 class HomePage(UniqueSlugMixin, Page):
+    parent_page_types = ["wagtailcore.Page"]
     subpage_types = [
-        "ContentPageIndex",
+        "home.ContentPageIndex",
     ]
 
 
 class ContentPageIndex(UniqueSlugMixin, Page):
+    parent_page_types = ["home.HomePage"]
     subpage_types = [
-        "ContentPage",
+        "home.ContentPage",
     ]
 
     include_in_homepage = models.BooleanField(default=False)
@@ -439,9 +441,7 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
         MARKETING = "MARKETING", _("Marketing")
         UTILITY = "UTILITY", _("Utility")
 
-    parent_page_type = [
-        "ContentPageIndex",
-    ]
+    parent_page_types = ["home.ContentPageIndex", "home.ContentPage"]
 
     # general page attributes
     tags = ClusterTaggableManager(through=ContentPageTag, blank=True)

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -7,8 +7,12 @@ from django.test import TestCase, override_settings
 from requests import HTTPError
 from wagtail.blocks import StructBlockValidationError
 from wagtail.images import get_image_model
+from wagtail.models import Page
+from wagtail.tests.utils import WagtailPageTests
 
 from home.models import (
+    ContentPage,
+    ContentPageIndex,
     GoToPageButton,
     HomePage,
     NextMessageButton,
@@ -20,6 +24,17 @@ from home.models import (
 
 from .page_builder import PageBuilder, WABlk, WABody
 from .utils import create_page, create_page_rating
+
+
+class MyPageTests(WagtailPageTests):
+    def test_contentpage_structure(self):
+        """
+        A ContentPage can only be created under a ContentPageIndex or another ContentPage. A ContentIndexPage can only be created under the HomePage.
+        """
+        self.assertCanNotCreateAt(Page, ContentPage)
+        self.assertCanNotCreateAt(HomePage, ContentPage)
+        self.assertCanNotCreateAt(ContentPage, ContentPageIndex)
+        self.assertCanNotCreateAt(Page, ContentPageIndex)
 
 
 class ContentPageTests(TestCase):


### PR DESCRIPTION
## Purpose
We cannot create `ContentPage`s under the root node, only under `ContentPageIndex`'s or other `ContentPage`s. 
## Approach
`ContentPage`'s cannot be created under the root or `HomePage`

