### PR TITLE
Test api

### DIFF
--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1218,7 +1218,7 @@ def mk_media(media_path: Path, title: str) -> File:
     return media
 
 
-def mk_doc(doc_path: Path, title: str) -> Image:
+def mk_doc(doc_path: Path, title: str) -> Document:
     doc = Document(title=title, file=File(doc_path.open("rb"), name=doc_path.name))
     doc.save()
     return doc


### PR DESCRIPTION
## Purpose
Increase test coverage for API and serializers

## Approach
add the following tests

- test_messenger_disabled
- test_web_disabled
- test_viber_disabled
- test_sms_disabled
- test_ussd_disabled
- test_wa_image
- test_viber_image
- test_messenger_image
- test_wa_doc
- test_wa_media
- test_wa_messages_only_1_image
- test_wa_messages_only_1_media
- test_wa_messages_only_1_doc
- test_whatsapp_template_variables
- test_list_items
- test_next_prompt
- test_footer
- test_empty_whatsapp

Note on image/doc/media testing: 
All messages that are created with the image/doc/media parameter will allocate the same image. This is done to minimise complexity. A test is added to ensure that only one image is created when multiple messages are created 

Fix: 
Incorrect Type in import tests 