### PR TITLE
added sentry env to contentrepo config

### DIFF
--- a/contentrepo/settings/production.py
+++ b/contentrepo/settings/production.py
@@ -18,6 +18,7 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS")
 
 SENTRY_DSN = env.str("SENTRY_DSN", "")
+SENTRY_ENVIRONMENT = env.str("SENTRY_ENVIRONMENT", "")
 if SENTRY_DSN:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
@@ -30,4 +31,5 @@ if SENTRY_DSN:
         integrations=[DjangoIntegration()],
         traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
         send_default_pii=SENTRY_SEND_DEFAULT_PII,
+        environment = SENTRY_ENVIRONMENT,
     )

--- a/contentrepo/settings/production.py
+++ b/contentrepo/settings/production.py
@@ -31,5 +31,5 @@ if SENTRY_DSN:
         integrations=[DjangoIntegration()],
         traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
         send_default_pii=SENTRY_SEND_DEFAULT_PII,
-        environment = SENTRY_ENVIRONMENT,
+        environment=SENTRY_ENVIRONMENT,
     )

--- a/contentrepo/settings/production.py
+++ b/contentrepo/settings/production.py
@@ -18,7 +18,7 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS")
 
 SENTRY_DSN = env.str("SENTRY_DSN", "")
-SENTRY_ENVIRONMENT = env.str("SENTRY_ENVIRONMENT", "")
+SENTRY_ENVIRONMENT = env.str("SENTRY_ENVIRONMENT", "production")
 if SENTRY_DSN:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration


### PR DESCRIPTION
I added the sentry environment config to contentrepo, so now we can associate errors based on qa or platform instances of contentrepo