### PR TITLE
Make a more informative message

### DIFF
--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -40,9 +40,17 @@ class ImportException(Exception):
     Base exception for all import related issues.
     """
 
-    def __init__(self, message: str, row_num: int | None = None):
+    def __init__(
+        self,
+        message: str,
+        row_num: int | None = None,
+        slug: str | None = None,
+        locale: Locale | None = None,
+    ):
         self.row_num = row_num
         self.message = message
+        self.slug = slug
+        self.locale = locale
         super().__init__()
 
 
@@ -117,6 +125,8 @@ class ContentImporter:
                     self.add_message_to_shadow_content_page_from_row(row, prev_locale)
             except ImportException as e:
                 e.row_num = i
+                e.slug = row.slug
+                e.locale = row.locale
                 raise e
 
     def save_pages(self) -> None:

--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -333,7 +333,7 @@ class ContentImporter:
             page = self.shadow_pages[(row.slug, locale)]
         except KeyError:
             raise ImportException(
-                f'This is a variation for the content page with slug "{row.slug}" and locale "{row.locale}", but no such page exists'
+                f"This is a variation for the content page with slug '{row.slug}' and locale '{locale}', but no such page exists"
             )
         whatsapp_block = page.whatsapp_body[-1]
         whatsapp_block.variation_messages.append(
@@ -349,7 +349,7 @@ class ContentImporter:
             page = self.shadow_pages[(row.slug, locale)]
         except KeyError:
             raise ImportException(
-                f'This is a message for page with slug "{row.slug}" and locale "{row.locale}", but no such page exists'
+                f"This is a message for page with slug '{row.slug}' and locale '{locale}', but no such page exists"
             )
         if row.is_whatsapp_message:
             page.enable_whatsapp = True

--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -326,20 +326,15 @@ class ContentImporter:
         if row.translation_tag or locale != self.default_locale():
             page.translation_key = row.translation_tag
 
-    def find_shadow_content_page(
-        self, row: "ContentRow", locale: Locale
-    ) -> "ShadowContentPage":
-        try:
-            return self.shadow_pages[(row.slug, locale)]
-        except KeyError:
-            raise ImportException(
-                f'This is a message for page with slug "{row.slug}" and locale "{row.locale}", but no such page exists'
-            )
-
     def add_variation_to_shadow_content_page_from_row(
         self, row: "ContentRow", locale: Locale
     ) -> None:
-        page = self.find_shadow_content_page(row, locale)
+        try:
+            page = self.shadow_pages[(row.slug, locale)]
+        except KeyError:
+            raise ImportException(
+                f'This is a variation for the content page with slug "{row.slug}" and locale "{row.locale}", but no such page exists'
+            )
         whatsapp_block = page.whatsapp_body[-1]
         whatsapp_block.variation_messages.append(
             ShadowVariationBlock(
@@ -350,7 +345,12 @@ class ContentImporter:
     def add_message_to_shadow_content_page_from_row(
         self, row: "ContentRow", locale: Locale
     ) -> None:
-        page = self.find_shadow_content_page(row, locale)
+        try:
+            page = self.shadow_pages[(row.slug, locale)]
+        except KeyError:
+            raise ImportException(
+                f'This is a message for page with slug "{row.slug}" and locale "{row.locale}", but no such page exists'
+            )
         if row.is_whatsapp_message:
             page.enable_whatsapp = True
             buttons = []

--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -333,7 +333,7 @@ class ContentImporter:
             return self.shadow_pages[(row.slug, locale)]
         except KeyError:
             raise ImportException(
-                f"Cannot find content page with slug '{row.slug}' and locale '{locale}'"
+                f'This is a message for page with slug "{row.slug}" and locale "{row.locale}", but no such page exists'
             )
 
     def add_variation_to_shadow_content_page_from_row(

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -817,8 +817,8 @@ class TestImportExport:
         assert e.value.row_num == 4
         assert (
             e.value.message
-            == "Cannot find content page with slug 'not-cp-import-export' and locale "
-            "'English'"
+            == "This is a message for page with slug 'not-cp-import-export' and locale "
+            "'English', but no such page exists"
         )
 
     def test_variation_for_missing_page(self, csv_impexp: ImportExport) -> None:
@@ -837,8 +837,8 @@ class TestImportExport:
         assert e.value.row_num == 4
         assert (
             e.value.message
-            == "Cannot find content page with slug 'not-cp-import-export' and locale "
-            "'English'"
+            == "This is a variation for the content page with slug 'not-cp-import-export' and locale "
+            "'English', but no such page exists"
         )
 
     def test_go_to_page_button_missing_page(self, csv_impexp: ImportExport) -> None:

--- a/home/views.py
+++ b/home/views.py
@@ -153,7 +153,7 @@ class ContentUploadThread(UploadThread):
             self.result_queue.put(
                 (
                     messages.ERROR,
-                    f'Row "{e.row_num}" is a message for page with slug "{e.slug}" and locale "{e.locale}", but no such page exists.',
+                    f"Content import failed on row {e.row_num}: {e.message}",
                 )
             )
         except Exception:

--- a/home/views.py
+++ b/home/views.py
@@ -153,7 +153,7 @@ class ContentUploadThread(UploadThread):
             self.result_queue.put(
                 (
                     messages.ERROR,
-                    f"Content import failed on row {e.row_num}: {e.message}",
+                    f'Row "{e.row_num}" is a message for page with slug "{e.slug}" and locale "{e.locale}", but no such page exists.',
                 )
             )
         except Exception:


### PR DESCRIPTION
## Purpose
Importing messages with no page causes an error that isn't very informative, leaving the user thinking the system is broken.

## Approach
Change the message to be more informative so that the user has an idea of what to do to fix it.
