### PR TITLE
Fix import orderedcontentset page

### DIFF
--- a/contentrepo/templates/orderedcontentset_upload.html
+++ b/contentrepo/templates/orderedcontentset_upload.html
@@ -55,7 +55,7 @@
 {% block extra_js %}
     <script>
       var importURL = "{% url 'import_orderedcontentset' %}";
-      var destinationURL = "{% url 'wagtailsnippets_home_orderedcontentset:index' %}";
+      var destinationURL = "{% url 'wagtailsnippets_home_orderedcontentset:list' %}";
     </script>
     <script type="text/javascript" src="{% static 'js/contentrepo.js' %}"></script>
 {% endblock %}

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import File  # type: ignore
 from django.core.files.images import ImageFile  # type: ignore
+from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 from wagtail.documents.models import Document  # type: ignore
 from wagtail.images.models import Image  # type: ignore
@@ -1223,3 +1224,14 @@ class TestOrderedContentSetAPI:
         )
 
         assert ordered_content_set_default_workflow == workflow
+
+    def test_get_upload(self, admin_client):
+        """
+        Should return the data and not throw an exception
+        """
+        url = reverse("import_orderedcontentset")
+        # NB gotta use the admin_client here
+        response = admin_client.get(f"{url}", follow=True)
+        content_str = response.content.decode("utf-8")
+        assert "/admin/snippets/home/orderedcontentset/" in content_str
+        assert response.status_code == 200


### PR DESCRIPTION
## Purpose
When you click on the Import button for Ordered Content sets it throws a 500 error. This is because the dynamic URL changed from :index to :list.

## Approach
I changed the dynamic URL to use the :list url.
