### PR TITLE
return status code 404 if page not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+-Page not found api status change to 404 from 400.
 
 ### Added
 

--- a/contentrepo/urls.py
+++ b/contentrepo/urls.py
@@ -71,7 +71,7 @@ urlpatterns = urlpatterns + [
     #    path("pages/", include(wagtail_urls)),
 ]
 
-urlpatterns += i18n_patterns(
-    path("search/", search_views.search, name="search"),
-    path("", include(wagtail_urls)),
-)
+# urlpatterns += i18n_patterns(
+#     path("search/", search_views.search, name="search"),
+#     path("", include(wagtail_urls)),
+# )

--- a/contentrepo/urls.py
+++ b/contentrepo/urls.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import include, path, reverse_lazy
 from django.views.generic.base import RedirectView

--- a/contentrepo/urls.py
+++ b/contentrepo/urls.py
@@ -69,8 +69,3 @@ urlpatterns = urlpatterns + [
     # of your site, rather than the site root:
     #    path("pages/", include(wagtail_urls)),
 ]
-
-# urlpatterns += i18n_patterns(
-#     path("search/", search_views.search, name="search"),
-#     path("", include(wagtail_urls)),
-# )

--- a/home/api.py
+++ b/home/api.py
@@ -1,4 +1,4 @@
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import NotFound
 from rest_framework.filters import SearchFilter
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
@@ -49,7 +49,7 @@ class ContentPagesViewSet(PagesAPIViewSet):
             else:
                 ContentPage.objects.get(id=pk).save_page_view(request.query_params)
         except ContentPage.DoesNotExist:
-            raise ValidationError({"page": ["Page matching query does not exist."]})
+            raise NotFound({"page": ["Page matching query does not exist."]})
 
         return super().detail_view(request, pk)
 

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -357,7 +357,7 @@ class TestContentPageAPI:
         page.save_revision().publish()
 
         response = uclient.get(f"/api/v2/pages/{page.id}/?{platform}=True")
-        assert response.content == b""
+        assert response.status_code == 404
 
     def test_message_number_specified_whatsapp(self, uclient):
         """
@@ -594,15 +594,10 @@ class TestContentPageAPI:
     def test_detail_view_no_content_page(self, uclient):
         """
         We get a validation error if we request a page that doesn't exist.
-
-        FIXME:
-         * Is 400 (ValidationError) really an appropriate response code for
-           this? 404 seems like a better fit for failing to find a page we're
-           looking up by id.
         """
         # it should return the validation error for content page that doesn't exist
         response = uclient.get("/api/v2/pages/1/")
-        assert response.status_code == 400
+        assert response.status_code == 404
 
         content = response.json()
         assert content == {"page": ["Page matching query does not exist."]}


### PR DESCRIPTION
## Purpose
Return status code for when a page doesn't exist instead of status code 400

## Solution
Change the exception from validation error to NotFound
Removed the i18n_patterns, this caused a redirect if there was no page found

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

