### PR TITLE
Add explainer to serializer and include tests

### DIFF
--- a/home/serializers.py
+++ b/home/serializers.py
@@ -538,7 +538,9 @@ class QuestionField(serializers.Field):
 
     Example:
     "question": {
+        "question_type": "categorical_question",
         "question": "How much wood would a woodchuck chuck if a woodchuck could chuck wood?",
+        "explainer": None,
         "error": "Unknown answer given",
         "answers": [
             {
@@ -554,12 +556,14 @@ class QuestionField(serializers.Field):
 
     def to_representation(self, page):
         questions = []
+
         for question in page.questions.raw_data:
             questions.append(
                 {
                     "id": question["id"],
                     "question_type": question["type"],
                     "question": question["value"]["question"],
+                    "explainer": question.get("value", {}).get("explainer"),
                     "error": question["value"]["error"],
                     "answers": [
                         x["value"] for x in question["value"].get("answers", [])

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -1474,6 +1474,7 @@ class TestAssessmentAPI:
             "id": self.assessment.questions[0].id,
             "question_type": "categorical_question",
             "question": "What is the best chocolate?",
+            "explainer": None,
             "error": "Invalid answer",
             "answers": [
                 {"answer": "Crunchie", "score": "5"},
@@ -1484,6 +1485,7 @@ class TestAssessmentAPI:
             "id": self.assessment.questions[1].id,
             "question_type": "age_question",
             "question": "How old are you?",
+            "explainer": None,
             "error": "Invalid answer",
             "answers": [],
         }
@@ -1491,6 +1493,7 @@ class TestAssessmentAPI:
             "id": self.assessment.questions[2].id,
             "question_type": "multiselect_question",
             "question": "Which chocolates are yummy?",
+            "explainer": None,
             "error": "Invalid answer",
             "answers": [
                 {"answer": "Crunchie", "score": "5"},

--- a/home/tests/test_serializers.py
+++ b/home/tests/test_serializers.py
@@ -1,7 +1,9 @@
 import pytest
+from wagtail.models import Locale  # type: ignore
 
-from home.models import ContentPage, HomePage
+from home.models import Assessment, ContentPage, HomePage
 from home.serializers import (
+    QuestionField,
     format_whatsapp_message,
     has_next_message,
     has_previous_message,
@@ -71,6 +73,135 @@ def create_content_page(
         bodies=bodies,
     )
     return content_page
+
+
+@pytest.fixture()
+def create_form_pages() -> None:
+    home_page = HomePage.objects.first()
+    main_menu = PageBuilder.build_cpi(home_page, "main-menu", "Main Menu")
+    PageBuilder.build_cp(
+        parent=main_menu,
+        slug="high-inflection",
+        title="High Inflection",
+        bodies=[
+            WABody("High Inflection", [WABlk("*High Inflection Page")]),
+            MBody("High inflection", [MBlk("High Inflection Page")]),
+        ],
+    )
+    PageBuilder.build_cp(
+        parent=main_menu,
+        slug="medium-score",
+        title="Medium Score",
+        bodies=[
+            WABody("Medium Score", [WABlk("*Medium Inflection Page")]),
+            MBody("Medium Score", [MBlk("Medium Inflection Page")]),
+        ],
+    )
+
+    PageBuilder.build_cp(
+        parent=main_menu,
+        slug="low-score",
+        title="Low Score",
+        bodies=[
+            WABody("Low Score", [WABlk("*Low Inflection Page")]),
+            MBody("Low Score", [MBlk("Low Inflection Page")]),
+        ],
+    )
+
+
+def create_form_with_fields() -> Assessment:
+    """
+    Create form with an explainer field and pass it
+    through the serializer
+    """
+
+    form = Assessment.objects.create(
+        title="test page",
+        slug="test-page",
+        locale=Locale.objects.get(language_code="en"),
+        high_result_page=ContentPage.objects.get(slug="high-inflection"),
+        high_inflection=3,
+        medium_result_page=ContentPage.objects.get(slug="medium-score"),
+        medium_inflection=2,
+        low_result_page=ContentPage.objects.get(slug="low-score"),
+        generic_error="error",
+        questions=[
+            {
+                "type": "categorical_question",
+                "value": {
+                    # "type": "categorical_question",
+                    # "question_type": "categorical_question",
+                    "question": "test question",
+                    "explainer": "We need to know this",
+                    "error": "test error",
+                    "answers": [
+                        {
+                            "id": "eb96ad43-c231-4493-a235-de88e60219ea",
+                            "type": "item",
+                            "value": {"score": 2.0, "answer": "A"},
+                        },
+                        {
+                            "id": "06576523-e9de-4585-a8cd-08cafd6ef56d",
+                            "type": "item",
+                            "value": {"score": 1.0, "answer": "B"},
+                        },
+                        {
+                            "id": "c2d71503-92bf-4557-b198-dac64737e27c",
+                            "type": "item",
+                            "value": {"score": 2.0, "answer": "C"},
+                        },
+                    ],
+                },
+            }
+        ],
+    )
+    return form
+
+
+def create_form_with_missing_fields() -> Assessment:
+    """
+    Create form without an explainer field and pass it
+    through the serializer
+    """
+
+    form = Assessment.objects.create(
+        title="Test",
+        slug="test",
+        locale=Locale.objects.get(language_code="en"),
+        high_result_page=ContentPage.objects.get(slug="high-inflection"),
+        high_inflection=3,
+        medium_result_page=ContentPage.objects.get(slug="medium-score"),
+        medium_inflection=2,
+        low_result_page=ContentPage.objects.get(slug="low-score"),
+        generic_error="error",
+        questions=[
+            {
+                "type": "categorical_question",
+                "value": {
+                    "question": "test question",
+                    "error": "test error",
+                    "answers": [
+                        {
+                            "id": "eb96ad43-c231-4493-a235-de88e60219ea",
+                            "type": "item",
+                            "value": {"score": 2.0, "answer": "A"},
+                        },
+                        {
+                            "id": "06576523-e9de-4585-a8cd-08cafd6ef56d",
+                            "type": "item",
+                            "value": {"score": 1.0, "answer": "B"},
+                        },
+                        {
+                            "id": "c2d71503-92bf-4557-b198-dac64737e27c",
+                            "type": "item",
+                            "value": {"score": 2.0, "answer": "C"},
+                        },
+                    ],
+                },
+            }
+        ],
+    )
+    return form
 
 
 @pytest.mark.django_db
@@ -328,4 +459,55 @@ class TestFormatMessage:
             },
             "id": f'{result["id"]}',
         }
+        assert result == expected_result
+
+
+@pytest.mark.usefixtures("create_form_pages")
+@pytest.mark.django_db
+class TestAssessmentSerializer:
+    def test_form_with_fields(self) -> None:
+        """
+        Test form with all fields
+        """
+        page = create_form_with_fields()
+        form_page = QuestionField()
+        result = form_page.to_representation(page)
+        expected_result = [
+            {
+                "question_type": "categorical_question",
+                "question": "test question",
+                "explainer": "We need to know this",
+                "error": "test error",
+                "answers": [
+                    {"score": 2.0, "answer": "A"},
+                    {"score": 1.0, "answer": "B"},
+                    {"score": 2.0, "answer": "C"},
+                ],
+            }
+        ]
+        result[0].pop("id")
+        assert result == expected_result
+
+    def test_form_with_missing_fields(self) -> None:
+        """
+        Test form with missing fields.
+        Ex: explainer field
+        """
+        page = create_form_with_missing_fields()
+        form_page = QuestionField()
+        result = form_page.to_representation(page)
+        expected_result = [
+            {
+                "question_type": "categorical_question",
+                "question": "test question",
+                "explainer": None,
+                "error": "test error",
+                "answers": [
+                    {"score": 2.0, "answer": "A"},
+                    {"score": 1.0, "answer": "B"},
+                    {"score": 2.0, "answer": "C"},
+                ],
+            }
+        ]
+        result[0].pop("id")
         assert result == expected_result


### PR DESCRIPTION
## Purpose
Surface explainer in the api.

## Solution
Add explainer to the serializer and avoid keyerrors since explainer field is optional and already published forms would not have it.

#### Checklist
- [x] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)

