### PR TITLE
Add validation for IntegerQuestionBlock min and max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Freetext question type for forms
 - Add Integer question with min and max values
 - Add Year of Birth type question type
+- Custom model validation for IntegerQuestionBlock min and max
 
 ### Changed
 - Increased SMS limit to 459 characters

--- a/home/models.py
+++ b/home/models.py
@@ -1349,6 +1349,16 @@ class IntegerQuestionBlock(BaseQuestionBlock):
     )
     answers = None
 
+    def clean(self, value):
+        result = super().clean(value)
+        min = result["min"]
+        max = result["max"]
+        if min == max:
+            raise ValidationError("min and max values need to be different")
+        if min > max:
+            raise ValidationError("min cannot be greater than max")
+        return result
+
 
 class YearofBirthQuestionBlock(BaseQuestionBlock):
     answers = None

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -25,6 +25,7 @@ from home.models import (
     ContentPageIndex,
     GoToPageButton,
     HomePage,
+    IntegerQuestionBlock,
     NextMessageButton,
     OrderedContentSet,
     PageView,
@@ -953,3 +954,32 @@ class TestWhatsAppTemplate:
         wat_from_db = WhatsAppTemplate.objects.last()
         assert wat_from_db.submission_status == "FAILED"
         assert "Error" in wat_from_db.submission_result
+
+
+class IntegerQuestionBlockTests(TestCase):
+    def create_min_max_value(
+        self,
+        min,
+        max,
+    ):
+        return {
+            "min": min,
+            "max": max,
+        }
+
+    def test_clean_identical_min_max(self):
+        """Min and Max values must not be the same"""
+        IntegerQuestionBlock().clean(self.create_min_max_value(min=40, max=50))
+
+        with self.assertRaises(ValidationError) as e:
+            IntegerQuestionBlock().clean(self.create_min_max_value(min=50, max=50))
+        self.assertEqual(
+            "min and max values need to be different",
+            e.exception.message,
+        )
+        with self.assertRaises(ValidationError) as e:
+            IntegerQuestionBlock().clean(self.create_min_max_value(min=50, max=40))
+        self.assertEqual(
+            "min cannot be greater than max",
+            e.exception.message,
+        )


### PR DESCRIPTION
## Purpose
We need some validation to enforce rules for IntegerQuestionBlock forms so that at form level, min and max values are not the same and min is not greater than max. 

## Solution
This pr or adds custom model validation to handle this.

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

