### PR TITLE
custom model validation for min and max to only accept positive values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Freetext question type for forms
 - Add Integer question with min and max values
 - Add Year of Birth type question type
-- Custom model validation for IntegerQuestionBlock min and max
 
 ### Changed
 - Increased SMS limit to 459 characters
@@ -32,7 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove pagination on page view report
 - Add tests for the pageview report filters
 - Make inflection points and results pages optional
-- Mkae min and max fields mandatory for integer question type
+- Make min and max fields mandatory for integer question type
+- Custom model validation for IntegerQuestionBlock min and max
+- Custom model validation for min and max values to only be positive
 
 -->
 ## v1.1.0

--- a/home/models.py
+++ b/home/models.py
@@ -1353,12 +1353,13 @@ class IntegerQuestionBlock(BaseQuestionBlock):
         result = super().clean(value)
         min = result["min"]
         max = result["max"]
+        if min < 0 or max < 0:
+            raise ValidationError("min and max cannot be less than zero")
         if min == max:
             raise ValidationError("min and max values need to be different")
         if min > max:
             raise ValidationError("min cannot be greater than max")
-        if min < 0 or max < 0:
-            raise ValidationError("min and max cannot be less than zero")
+
         return result
 
 

--- a/home/models.py
+++ b/home/models.py
@@ -1357,6 +1357,8 @@ class IntegerQuestionBlock(BaseQuestionBlock):
             raise ValidationError("min and max values need to be different")
         if min > max:
             raise ValidationError("min cannot be greater than max")
+        if min < 0 or max < 0:
+            raise ValidationError("min and max cannot be less than zero")
         return result
 
 

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -992,7 +992,7 @@ class IntegerQuestionBlockTests(TestCase):
         with self.assertRaises(ValidationError) as e:
             IntegerQuestionBlock().clean(self.create_min_max_value(min=50, max=-40))
         self.assertEqual(
-            "min cannot be greater than max",
+            "min and max cannot be less than zero",
             e.exception.message,
         )
         with self.assertRaises(ValidationError) as e:

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -983,3 +983,9 @@ class IntegerQuestionBlockTests(TestCase):
             "min cannot be greater than max",
             e.exception.message,
         )
+        with self.assertRaises(ValidationError) as e:
+            IntegerQuestionBlock().clean(self.create_min_max_value(min=-50, max=40))
+        self.assertEqual(
+            "min and max cannot be less than zero",
+            e.exception.message,
+        )

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -989,3 +989,15 @@ class IntegerQuestionBlockTests(TestCase):
             "min and max cannot be less than zero",
             e.exception.message,
         )
+        with self.assertRaises(ValidationError) as e:
+            IntegerQuestionBlock().clean(self.create_min_max_value(min=50, max=-40))
+        self.assertEqual(
+            "min cannot be greater than max",
+            e.exception.message,
+        )
+        with self.assertRaises(ValidationError) as e:
+            IntegerQuestionBlock().clean(self.create_min_max_value(min=-60, max=-50))
+        self.assertEqual(
+            "min and max cannot be less than zero",
+            e.exception.message,
+        )


### PR DESCRIPTION
## Purpose
We do not need IntegerQuestion type to hold negative min and max values as there's no real world use case for it in this form.

## Solution
Add custom validation to make sure that negative vaues for min and max are not saved.

#### Checklist
- [ ] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)

