### PR TITLE
Raise ImportException for missing slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
--Page not found api status change to 404 from 400.
-- Use cache for data when importing assessments with xlsx. 
+- Page not found api status change to 404 from 400
+- Use cache for data when importing assessments with xlsx
+- Better error handling for missing when importing content
 
 ### Added
 - content page import validation using the model

--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -828,6 +828,8 @@ class ContentRow:
             for key, value in row.items()
             if value and key in class_fields
         }
+        if "slug" not in row:
+            raise ImportException("Missing slug value", row_num)
         return cls(
             page_id=int(row.pop("page_id")) if row.get("page_id") else None,
             variation_title=deserialise_dict(row.pop("variation_title", "")),

--- a/home/tests/import-export-data/missing-slug-index.csv
+++ b/home/tests/import-export-data/missing-slug-index.csv
@@ -1,0 +1,3 @@
+structure,message,page_id,slug,parent,web_title,web_subtitle,web_body,whatsapp_title,whatsapp_body,whatsapp_template_name,whatsapp_template_category,example_values,variation_title,variation_body,list_items,sms_title,sms_body,ussd_title,ussd_body,messenger_title,messenger_body,viber_title,viber_body,translation_tag,tags,quick_replies,triggers,locale,next_prompt,buttons,image_link,doc_link,media_link,related_pages,footer
+Menu 1,0,659,,,MA_import export,,,,,,,,,,,,,,,,,,,,,,,English,,,,,,,
+Sub 1.1,1,660,locale-import,MA_import export,Locale import,,,import per locale,this is the english message..edit,,UTILITY,,,,,,,,,,,,,,,,,English,,[],,,,,

--- a/home/tests/import-export-data/missing-slug.csv
+++ b/home/tests/import-export-data/missing-slug.csv
@@ -1,0 +1,3 @@
+structure,message,page_id,slug,parent,web_title,web_subtitle,web_body,whatsapp_title,whatsapp_body,whatsapp_template_name,whatsapp_template_category,example_values,variation_title,variation_body,list_items,sms_title,sms_body,ussd_title,ussd_body,messenger_title,messenger_body,viber_title,viber_body,translation_tag,tags,quick_replies,triggers,locale,next_prompt,buttons,image_link,doc_link,media_link,related_pages,footer
+Menu 1,0,659,ma_import-export,,MA_import export,,,,,,,,,,,,,,,,,,,,,,,English,,,,,,,
+Sub 1.1,1,660,,MA_import export,Locale import,,,import per locale,this is the english message..edit,,UTILITY,,,,,,,,,,,,,,,,,English,,[],,,,,

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -682,11 +682,25 @@ class TestImportExport:
         (This uses missing-slug.csv.)
         """
 
-        # One of the page rows doesn't have a slug.
+        # One of the content page rows doesn't have a slug.
         with pytest.raises(ImportException) as e:
             csv_impexp.import_file("missing-slug.csv")
 
         assert e.value.row_num == 3
+        assert e.value.message == ["Missing slug value"]
+
+    def test_missing_slug_on_index_page(self, csv_impexp: ImportExport) -> None:
+        """
+        Importing index pages without slugs causes a validation error.
+
+        (This uses missing-slug-index.csv.)
+        """
+
+        # One of the index page rows doesn't have a slug.
+        with pytest.raises(ImportException) as e:
+            csv_impexp.import_file("missing-slug-index.csv")
+
+        assert e.value.row_num == 2
         assert e.value.message == ["Missing slug value"]
 
     def test_no_translation_key_default(self, csv_impexp: ImportExport) -> None:

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -667,13 +667,27 @@ class TestImportExport:
         csv_bytes = csv_impexp.import_file("content2.csv")
 
         # This CSV doesn't have any of the fields we expect.
-        with pytest.raises((KeyError, TypeError)):
+        with pytest.raises((KeyError, TypeError, ImportException)):
             csv_impexp.import_file("broken.csv")
 
         # The export should match the existing content.
         content = csv_impexp.export_content()
         src, dst = csv_impexp.csvs2dicts(csv_bytes, content)
         assert dst == src
+
+    def test_missing_slug(self, csv_impexp: ImportExport) -> None:
+        """
+        Importing pages without slugs causes a validation error.
+
+        (This uses missing-slug.csv.)
+        """
+
+        # One of the page rows doesn't have a slug.
+        with pytest.raises(ImportException) as e:
+            csv_impexp.import_file("missing-slug.csv")
+
+        assert e.value.row_num == 3
+        assert e.value.message == ["Missing slug value"]
 
     def test_no_translation_key_default(self, csv_impexp: ImportExport) -> None:
         """


### PR DESCRIPTION
## Purpose
Page rows with missing slugs fail before most of our validation, so we don't get a useful error response for them.

## Solution
Raise an ImportException for pages with missing slugs. This is the only mandatory field in ContentRow, so having it as a special case is fine.

#### Checklist
- [X] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

