### PR TITLE
Filter answers for imported and non-imported forms

### DIFF
--- a/home/serializers.py
+++ b/home/serializers.py
@@ -573,7 +573,7 @@ class QuestionField(serializers.Field):
                     "max": question.get("value", {}).get("max"),
                     "semantic_id": question.get("value", {}).get("semantic_id"),
                     "answers": [
-                        x["value"] for x in question["value"].get("answers", [])
+                        x.get("value", x) for x in question["value"].get("answers", [])
                     ],
                 }
             )


### PR DESCRIPTION
## Purpose
The API returns different results for imported and non-imported forms, crashing with imported forms because we expect the data to be in a different format. This makes the API return the same results, regardless of how the Form was created.

## Solution
Get question['value'] if it's there, otherwise just give back the question results.

#### Checklist
- [x] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)

