### PR TITLE
Fix detail url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Removed
 - Removed word embeddings search (`s` query parameter in API)
+### Fixed
+- API: Fix detail URL in Pages API
 -->
 
 ## v1.2.1

--- a/home/models.py
+++ b/home/models.py
@@ -1321,9 +1321,6 @@ class AssessmentTag(TaggedItemBase):
     )
 
 
-from home.serializers import ContentPageSerializer  # noqa: E402, I001
-
-
 class Assessment(DraftStateMixin, RevisionMixin, index.Indexed, ClusterableModel):
     title = models.CharField(max_length=255)
     slug = models.SlugField(
@@ -1419,13 +1416,13 @@ class Assessment(DraftStateMixin, RevisionMixin, index.Indexed, ClusterableModel
         APIField("title"),
         APIField("slug"),
         APIField("version"),
-        APIField("high_result_page", serializer=ContentPageSerializer()),  # noqa: F821
+        APIField("high_result_page"),  # noqa: F821
         APIField("high_inflection"),
-        APIField("medium_result_page", serializer=ContentPageSerializer()),
+        APIField("medium_result_page"),
         APIField("medium_inflection"),
-        APIField("low_result_page", serializer=ContentPageSerializer()),
+        APIField("low_result_page"),
         APIField("skip_threshold"),
-        APIField("skip_high_result_page", serializer=ContentPageSerializer()),
+        APIField("skip_high_result_page"),
         APIField("generic_error"),
         APIField("questions"),
     ]

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -505,6 +505,42 @@ class TestContentPageAPI:
             "has_children": False,
         }
 
+    @pytest.mark.parametrize("platform", ALL_PLATFORMS)
+    def test_detail_view_meta(self, uclient, platform):
+        """
+        Fetching the detail view of a page returns the page metadata.
+        """
+        page = self.create_content_page(tags=["self_help"], body_type=platform)
+        response = uclient.get(f"/api/v2/pages/{page.id}/")
+        content = response.json()
+
+        # There's a lot of metadata, so only check selected fields.
+        meta = content.pop("meta")
+        parent = page.get_parent()
+
+        assert meta == {
+            "type": "home.ContentPage",
+            "detail_url": f"http://localhost/api/v2/pages/{page.id}/",
+            "html_url": page.get_full_url(),
+            "slug": page.slug,
+            "show_in_menus": "false",
+            "seo_title": page.seo_title,
+            "search_description": page.search_description,
+            "first_published_at": page.first_published_at.strftime(
+                "%Y-%m-%dT%H:%M:%S.%fZ"
+            ),
+            "alias_of": page.alias_of,
+            "parent": {
+                "id": parent.id,
+                "meta": {
+                    "type": "home.ContentPageIndex",
+                    "html_url": parent.get_full_url(),
+                },
+                "title": parent.title,
+            },
+            "locale": "en",
+        }
+
     def test_detail_view_increments_count(self, uclient):
         """
         Fetching the detail view of a page increments the view count.

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -491,6 +491,7 @@ class TestContentPageAPI:
         assert meta["slug"] == page.slug
         assert meta["parent"]["id"] == page.get_parent().id
         assert meta["locale"] == "en"
+        assert meta["detail_url"] == f"http://localhost/api/v2/pages/{page.id}/"
 
         assert content == {
             "id": page.id,
@@ -540,6 +541,7 @@ class TestContentPageAPI:
         assert meta["slug"] == page.slug
         assert meta["parent"]["id"] == page.get_parent().id
         assert meta["locale"] == "en"
+        assert meta["detail_url"] == f"http://localhost/api/v2/pages/{page.id}/"
 
         assert content["has_children"] is True
 
@@ -559,6 +561,7 @@ class TestContentPageAPI:
         assert meta["slug"] == page.slug
         assert meta["parent"]["id"] == page.get_parent().id
         assert meta["locale"] == "en"
+        assert meta["detail_url"] == f"http://localhost/api/v2/pages/{page.id}/"
 
         assert content["id"] == page.id
         assert content["title"] == "default page"
@@ -605,6 +608,7 @@ class TestContentPageAPI:
         assert meta["slug"] == page.slug
         assert meta["parent"]["id"] == page.get_parent().id
         assert meta["locale"] == "en"
+        assert meta["detail_url"] == f"http://localhost/api/v2/pages/{page.id}/"
 
         assert content["id"] == page.id
         assert content["title"] == "default page"
@@ -1499,6 +1503,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.high_result_page.slug
         assert meta["parent"]["id"] == self.high_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.high_result_page.id}/"
+        )
         assert content["results"][0]["high_result_page"] == {
             "id": self.high_result_page.id,
             "title": self.high_result_page.title,
@@ -1517,6 +1525,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.medium_result_page.slug
         assert meta["parent"]["id"] == self.medium_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.medium_result_page.id}/"
+        )
         assert content["results"][0]["medium_result_page"] == {
             "id": self.medium_result_page.id,
             "title": self.medium_result_page.title,
@@ -1535,6 +1547,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.low_result_page.slug
         assert meta["parent"]["id"] == self.low_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.low_result_page.id}/"
+        )
         assert content["results"][0]["low_result_page"] == {
             "id": self.low_result_page.id,
             "title": self.low_result_page.title,
@@ -1552,6 +1568,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.skip_high_result_page.slug
         assert meta["parent"]["id"] == self.skip_high_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.skip_high_result_page.id}/"
+        )
         assert content["results"][0]["skip_high_result_page"] == {
             "id": self.skip_high_result_page.id,
             "title": self.skip_high_result_page.title,
@@ -1655,6 +1675,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.high_result_page.slug
         assert meta["parent"]["id"] == self.high_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.high_result_page.id}/"
+        )
         assert content["high_result_page"] == {
             "id": self.high_result_page.id,
             "title": self.high_result_page.title,
@@ -1673,6 +1697,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.medium_result_page.slug
         assert meta["parent"]["id"] == self.medium_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.medium_result_page.id}/"
+        )
         assert content["medium_result_page"] == {
             "id": self.medium_result_page.id,
             "title": self.medium_result_page.title,
@@ -1691,6 +1719,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.low_result_page.slug
         assert meta["parent"]["id"] == self.low_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.low_result_page.id}/"
+        )
         assert content["low_result_page"] == {
             "id": self.low_result_page.id,
             "title": self.low_result_page.title,
@@ -1723,6 +1755,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.high_result_page.slug
         assert meta["parent"]["id"] == self.high_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.high_result_page.id}/"
+        )
         assert content["results"][0]["high_result_page"] == {
             "id": self.high_result_page.id,
             "title": self.high_result_page.title,
@@ -1741,6 +1777,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.medium_result_page.slug
         assert meta["parent"]["id"] == self.medium_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.medium_result_page.id}/"
+        )
         assert content["results"][0]["medium_result_page"] == {
             "id": self.medium_result_page.id,
             "title": self.medium_result_page.title,
@@ -1759,6 +1799,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.low_result_page.slug
         assert meta["parent"]["id"] == self.low_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.low_result_page.id}/"
+        )
         assert content["results"][0]["low_result_page"] == {
             "id": self.low_result_page.id,
             "title": self.low_result_page.title,
@@ -1804,6 +1848,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.high_result_page.slug
         assert meta["parent"]["id"] == self.high_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.high_result_page.id}/"
+        )
         assert content["high_result_page"] == {
             "id": self.high_result_page.id,
             "title": self.high_result_page.title,
@@ -1822,6 +1870,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.medium_result_page.slug
         assert meta["parent"]["id"] == self.medium_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.medium_result_page.id}/"
+        )
         assert content["medium_result_page"] == {
             "id": self.medium_result_page.id,
             "title": self.medium_result_page.title,
@@ -1840,6 +1892,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.low_result_page.slug
         assert meta["parent"]["id"] == self.low_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.low_result_page.id}/"
+        )
         assert content["low_result_page"] == {
             "id": self.low_result_page.id,
             "title": self.low_result_page.title,
@@ -1852,18 +1908,17 @@ class TestAssessmentAPI:
             "triggers": [],
         }
 
-    # TODO: Add this test in once we've merged with main - there's some code in there that makes following the redirect work
-    # def test_assessment_detail_endpoint_without_drafts(self, uclient, settings):
-    #     """
-    #     Unpublished assessments are not returned if the qa param is not set.
-    #     """
-    #     settings.STATIC_ROOT = Path("home/tests/test_static")
-    #     self.assessment.unpublish()
-    #     url = f"/api/v2/assessment/{self.assessment.id}"
+    def test_assessment_detail_endpoint_without_drafts(self, uclient, settings):
+        """
+        Unpublished assessments are not returned if the qa param is not set.
+        """
+        settings.STATIC_ROOT = Path("home/tests/test_static")
+        self.assessment.unpublish()
+        url = f"/api/v2/assessment/{self.assessment.id}"
 
-    #     response = uclient.get(url, follow=True)
+        response = uclient.get(url, follow=True)
 
-    #     assert response.status_code == 404
+        assert response.status_code == 404
 
     def test_assessment_new_draft(self, uclient):
         """
@@ -1906,6 +1961,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.high_result_page.slug
         assert meta["parent"]["id"] == self.high_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.high_result_page.id}/"
+        )
         assert content["results"][0]["high_result_page"] == {
             "id": self.high_result_page.id,
             "title": self.high_result_page.title,
@@ -1924,6 +1983,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.medium_result_page.slug
         assert meta["parent"]["id"] == self.medium_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.medium_result_page.id}/"
+        )
         assert content["results"][0]["medium_result_page"] == {
             "id": self.medium_result_page.id,
             "title": self.medium_result_page.title,
@@ -1942,6 +2005,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.low_result_page.slug
         assert meta["parent"]["id"] == self.low_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.low_result_page.id}/"
+        )
         assert content["results"][0]["low_result_page"] == {
             "id": self.low_result_page.id,
             "title": self.low_result_page.title,
@@ -1963,6 +2030,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == high_result_page.slug
         assert meta["parent"]["id"] == high_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{high_result_page.id}/"
+        )
         assert content["results"][0]["high_result_page"] == {
             "id": high_result_page.id,
             "title": high_result_page.title,
@@ -1981,6 +2052,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.medium_result_page.slug
         assert meta["parent"]["id"] == self.medium_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.medium_result_page.id}/"
+        )
         assert content["results"][0]["medium_result_page"] == {
             "id": self.medium_result_page.id,
             "title": self.medium_result_page.title,
@@ -1999,6 +2074,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.low_result_page.slug
         assert meta["parent"]["id"] == self.low_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.low_result_page.id}/"
+        )
         assert content["results"][0]["low_result_page"] == {
             "id": self.low_result_page.id,
             "title": self.low_result_page.title,
@@ -2022,6 +2101,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.high_result_page.slug
         assert meta["parent"]["id"] == self.high_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.high_result_page.id}/"
+        )
         assert content["results"][0]["high_result_page"] == {
             "id": self.high_result_page.id,
             "title": self.high_result_page.title,
@@ -2040,6 +2123,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.medium_result_page.slug
         assert meta["parent"]["id"] == self.medium_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.medium_result_page.id}/"
+        )
         assert content["results"][0]["medium_result_page"] == {
             "id": self.medium_result_page.id,
             "title": self.medium_result_page.title,
@@ -2058,6 +2145,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.low_result_page.slug
         assert meta["parent"]["id"] == self.low_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.low_result_page.id}/"
+        )
         assert content["results"][0]["low_result_page"] == {
             "id": self.low_result_page.id,
             "title": self.low_result_page.title,
@@ -2084,6 +2175,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.high_result_page.slug
         assert meta["parent"]["id"] == self.high_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.high_result_page.id}/"
+        )
         assert content["high_result_page"] == {
             "id": self.high_result_page.id,
             "title": self.high_result_page.title,
@@ -2102,6 +2197,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.medium_result_page.slug
         assert meta["parent"]["id"] == self.medium_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.medium_result_page.id}/"
+        )
         assert content["medium_result_page"] == {
             "id": self.medium_result_page.id,
             "title": self.medium_result_page.title,
@@ -2120,6 +2219,10 @@ class TestAssessmentAPI:
         assert meta["slug"] == self.low_result_page.slug
         assert meta["parent"]["id"] == self.low_result_page.get_parent().id
         assert meta["locale"] == "en"
+        assert (
+            meta["detail_url"]
+            == f"http://localhost/api/v2/pages/{self.low_result_page.id}/"
+        )
         assert content["low_result_page"] == {
             "id": self.low_result_page.id,
             "title": self.low_result_page.title,


### PR DESCRIPTION
## Purpose
The detail_url in the Pages API is currently showing the current URL and not the detail URL, which causes a failure on one of our implementations.

## Solution
We use `get_object_detail_url` to get the correct detail url for the Page. Trying to use super() and building on that doesn't work, as it seems to cause a cascade of errors when Assessments serialize a Page.

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [x] Updated readme/documentation (if necessary)

