### PR TITLE
new branch for ordered content export fix

### DIFF
--- a/home/content_import_export.py
+++ b/home/content_import_export.py
@@ -37,6 +37,25 @@ def export_csv_content(queryset: PageQuerySet, response: HttpResponse) -> None:
     ExportWriter(export_rows).write_csv(response)
 
 
+"""Ordered Content Sets Imports/Export"""
+
+
+def export_xlsx_ordered_content(queryset: PageQuerySet, response: HttpResponse) -> None:
+    from .export_ordered_sets import OrderedSetExporter, OrderedSetsExportWriter
+
+    exporter = OrderedSetExporter(queryset)
+    export_rows = exporter.perform_export()
+    OrderedSetsExportWriter(export_rows).write_xlsx(response)
+
+
+def export_csv_ordered_content(queryset: PageQuerySet, response: HttpResponse) -> None:
+    from .export_ordered_sets import OrderedSetExporter, OrderedSetsExportWriter
+
+    exporter = OrderedSetExporter(queryset)
+    export_rows = exporter.perform_export()
+    OrderedSetsExportWriter(export_rows).write_csv(response)
+
+
 def import_ordered_sets(file, filetype, progress_queue, purge=False):
     def create_ordered_set_from_row(row):
         set_name = row["Name"]

--- a/home/export_ordered_sets.py
+++ b/home/export_ordered_sets.py
@@ -1,0 +1,134 @@
+import copy
+import csv
+from collections.abc import Iterable
+from dataclasses import asdict, astuple, dataclass, fields
+from math import ceil
+
+from django.http import HttpResponse  # type: ignore
+from openpyxl.styles import Font, NamedStyle
+from openpyxl.utils import get_column_letter
+from openpyxl.workbook import Workbook
+from openpyxl.worksheet.worksheet import Worksheet
+from wagtail.query import QuerySet  # type: ignore  # No typing available
+
+
+@dataclass
+class ExportRow:
+    """
+    All the data for a single row of an ordered content set
+    """
+
+    name: str
+    profile_field: str
+    page_slugs: str
+    time: int | None
+    unit: str | None
+    before_or_after: str | None
+    contact_field: str | None
+
+    @classmethod
+    def headings(cls) -> list[str]:
+        """
+        The field names, used to write the header rows in exports
+        """
+        return [f.name for f in fields(cls)]
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+    def to_tuple(self) -> tuple[str]:
+        return astuple(self)
+
+
+class OrderedSetExporter:
+    rows: list[ExportRow]
+
+    def __init__(self, queryset: QuerySet):
+        self.queryset = queryset
+        self.rows = []
+
+    def perform_export(self) -> Iterable[ExportRow]:
+        for item in self.queryset:
+            yield ExportRow(
+                name=item.name,
+                profile_field=item.profile_field,
+                page_slugs=item.page_slugs,
+                time=item.time,
+                unit=item.unit,
+                before_or_after=str(item.before_or_after),
+                contact_field=item.contact_field,
+            )
+
+
+class OrderedSetsExportWriter:
+    rows: Iterable[ExportRow]
+
+    def __init__(self, rows: Iterable[ExportRow]):
+        self.rows = rows
+
+    def write_xlsx(self, response: HttpResponse) -> None:
+        workbook = Workbook()
+        worksheet: Worksheet = workbook.active  # type: ignore  # This is not a write or read only workbook
+        worksheet.append(ExportRow.headings())
+        for row in self.rows:
+            worksheet.append(row.to_tuple())
+        _set_xlsx_styles(workbook, worksheet)
+        workbook.save(response)
+
+    def write_csv(self, response: HttpResponse) -> None:
+        writer = csv.DictWriter(f=response, fieldnames=ExportRow.headings())
+        writer.writeheader()
+
+        for row in self.rows:
+            writer.writerow(row.to_dict())
+
+
+def _set_xlsx_styles(wb: Workbook, sheet: Worksheet) -> None:
+    """
+    Sets the style for the workbook adding any formatting that will make the sheet more
+    aesthetically pleasing
+    """
+    # Adjustment is because the size in openxlsx and google sheets are not equivalent
+    adjustment = 7
+
+    # Set columns based on best size
+    column_widths_in_pts = {
+        "name": 130,
+        "profile_field": 110,
+        "page_slugs": 100,
+        "time": 100,
+        "unit": 110,
+        "before_or_after": 120,
+        "contact_field": 100,
+    }
+    for column in sheet.iter_cols(max_row=1):
+        [cell] = column
+        width = column_widths_in_pts[str(cell.value)]
+        sheet.column_dimensions[get_column_letter(cell.col_idx)].width = ceil(
+            width / adjustment
+        )
+
+    # Named Styles
+    header_style = NamedStyle(name="header_style")
+
+    # Set attributes to styles
+    header_style.font = Font(bold=True, size=10)
+
+    # Add named styles to wb
+    wb.add_named_style(header_style)
+
+    # Set header style for row 1
+    for row in sheet["1:2"]:
+        for cell in row:
+            cell.style = header_style
+
+    # set font on all cells initially to 10pt and row height
+    general_font = Font(size=10)
+    for index, row in enumerate(sheet.iter_rows()):
+        if index > 2:
+            sheet.row_dimensions[index].height = 60  # type: ignore # Bad annotation.
+        for cell in row:
+            cell.font = general_font
+            alignment = copy.copy(cell.alignment)
+            alignment.wrapText = True
+            cell.alignment = alignment  # type: ignore # Broken typeshed update, maybe?

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -125,18 +125,13 @@ def csv2dicts(csv_bytes: bytes) -> ExpDicts:
 
 
 def xlsx2dicts(xlsx_bytes: bytes) -> ExpDicts:
-    # Load the Excel file from bytes
-    excel_file = BytesIO(xlsx_bytes)
-    workbook = load_workbook(excel_file)
 
-    # Assume the data is in the first sheet
-    sheet = workbook.active
+    workbook = load_workbook(BytesIO(xlsx_bytes))
+    worksheet = get_active_sheet(workbook)
+    header = next(worksheet.iter_rows(max_row=1, values_only=True))
+    headers = [str(cell) if cell is not None else "" for cell in header]
 
-    # Get the headers from the first row
-    headers = [cell.value for cell in sheet[1]]
-
-    # Iterate over the remaining rows and convert each row to a dictionary
-    for row in sheet.iter_rows(min_row=2, values_only=True):
+    for row in worksheet.iter_rows(values_only=True):  # type: ignore
         yield {headers[i]: row[i] for i in range(len(headers))}
 
 


### PR DESCRIPTION
## Purpose
[Old branch- 356](https://github.com/praekeltfoundation/contentrepo/pull/356) became unusable 

## Solution
We can now export ordered content sets in xlsx

#### Checklist
- [X] Added or updated unit tests


