### PR TITLE
Updated Standalone Whatsapp Templates  list column titles and values

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -1656,8 +1656,7 @@ class WhatsAppTemplate(
             revision.content["submission_name"] = self.template_name
             revision.content["submission_status"] = self.SubmissionStatus.SUBMITTED
             revision.content["submission_result"] = (
-                # f"Success! Template ID = {response_json['id']}"
-                "Success! Template ID = some_id"
+                f"Success! Template ID = {response_json['id']}"
             )
         except TemplateSubmissionException as e:
             # The submission failed

--- a/home/models.py
+++ b/home/models.py
@@ -1523,12 +1523,25 @@ class WhatsAppTemplate(
         SUBMITTED = "SUBMITTED", _("Submitted")
         FAILED = "FAILED", _("Failed")
 
+    def get_submission_status_display(self):
+        return self.SubmissionStatus(self.submission_status).label
+
+    get_submission_status_display.admin_order_field = "submission status"
+    get_submission_status_display.short_description = "Submission status"
+
     name = models.CharField(max_length=512, blank=True, default="")
     category = models.CharField(
         max_length=14,
         choices=Category.choices,
         default=Category.MARKETING,
     )
+
+    def get_category_display(self):
+        return self.Category(self.category).label
+
+    get_category_display.admin_order_field = "category"
+    get_category_display.short_description = "Category"
+
     quick_replies = ClusterTaggableManager(
         through="home.TemplateQuickReplyContent", blank=True
     )
@@ -1643,7 +1656,8 @@ class WhatsAppTemplate(
             revision.content["submission_name"] = self.template_name
             revision.content["submission_status"] = self.SubmissionStatus.SUBMITTED
             revision.content["submission_result"] = (
-                f"Success! Template ID = {response_json['id']}"
+                # f"Success! Template ID = {response_json['id']}"
+                "Success! Template ID = some_id"
             )
         except TemplateSubmissionException as e:
             # The submission failed

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -247,11 +247,12 @@ class WhatsAppTemplateAdmin(SnippetViewSet):
     list_export = "name"
     list_display = (
         "name",
-        "category",
+        "get_category_display",
         "locale",
         "status",
-        "submission_status",
+        "get_submission_status_display",
     )
+
     list_filter = ("locale",)
 
     search_fields = (


### PR DESCRIPTION
## Purpose
QA logged the following two issues:

- After you save a template with correct info the page submission status shows as Submitted. but on the home page it shows as NOT_SUBMITTED_YET
- Also can we format this text to not have underscores on the templates home page and have the text look like all other statuses in content repo.


## Solution
- I check with Rudi and this is the standard Wagtail behaviour.  The list view always displays the most recent published revision, while the edit screen shows the latest revision available.  You should see that ContentPages behave the same
- Have updated the list column titles and values to be more in line with the rest of the list views

#### Checklist
- [NA] Added or updated unit tests
- [NA] Added to release notes
- [NA] Updated readme/documentation (if necessary)

