### PR TITLE
Return all pages if no tag is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - API: Fix detail URL in Pages API
 - Forms: Added model import validation so that required fields are flagged on import
+- API: Return all pages if tag keyword is specified without tags
 
 ### Security
 - Updated sentry-sdk from 1.44.1 to 2.8.0

--- a/home/api.py
+++ b/home/api.py
@@ -106,7 +106,7 @@ class ContentPagesViewSet(PagesAPIViewSet):
             queryset = queryset.filter(enable_viber=True)
 
         tag = self.request.query_params.get("tag")
-        if tag is not None:
+        if tag:
             ids = []
             for t in ContentPageTag.objects.filter(tag__name__iexact=tag):
                 ids.append(t.content_object_id)

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -274,6 +274,11 @@ class TestContentPageAPI:
         content = json.loads(response.content)
         assert content["count"] == 2
 
+        # it should return all pages for no tag, excluding home pages and index pages
+        response = uclient.get("/api/v2/pages/?tag=")
+        content = json.loads(response.content)
+        assert content["count"] == 3
+
     def test_platform_filtering(self, uclient):
         """
         If a platform filter is provided, only pages with content for that


### PR DESCRIPTION
## Purpose
If we specify the `tag` query param but give no tags, CMS returns nothing. This makes it so that CMS returns the everything (the same as if we didn't specify the tag param.

## Solution
_What changed, and does this address the problem? _

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

