### PR TITLE
Add page keyword to query params for assessments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API: Fix detail URL in Pages API
 - Forms: Added model import validation so that required fields are flagged on import
 - API: Return all pages if tag keyword is specified without tags
+- API: Added page keyword to Assessments API
 
 ### Security
 - Updated sentry-sdk from 1.44.1 to 2.8.0

--- a/home/api.py
+++ b/home/api.py
@@ -199,6 +199,7 @@ class AssessmentViewSet(BaseAPIViewSet):
         [
             "tag",
             "qa",
+            "page",
         ]
     )
     model = Assessment

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -1526,6 +1526,11 @@ class TestAssessmentAPI:
         )
         self.assessment.save()
 
+    def test_assessment_endpoint_with_page_keyword(self, uclient):
+        response = uclient.get("/api/v2/assessment/?page=1")
+        content = json.loads(response.content)
+        assert content["count"] == 1
+
     def test_assessment_endpoint(self, uclient):
         response = uclient.get("/api/v2/assessment/")
         content = json.loads(response.content)


### PR DESCRIPTION
## Purpose
Assessments should be paginated but we don't allow the page keyword in query params

## Solution
I added the page keyword

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

