### PR TITLE
Fix Ordered Content import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Forms: Added model import validation so that required fields are flagged on import
 - API: Return all pages if tag keyword is specified without tags
 - API: Added page keyword to Assessments API
+- Ordered Content Sets: Import now allows for CSV values in time, unit, before or after, and contact field
 
 ### Security
 - Updated sentry-sdk from 1.44.1 to 2.8.0

--- a/home/content_import_export.py
+++ b/home/content_import_export.py
@@ -1,15 +1,10 @@
-import csv
-import io
-from io import BytesIO
 from logging import getLogger
+from queue import Queue
 
+from django.core.files.base import File  # type: ignore
 from django.db import transaction
 from django.http import HttpResponse
-from openpyxl import load_workbook
 from wagtail.query import PageQuerySet
-
-from home.import_helpers import ImportException
-from home.models import ContentPage, OrderedContentSet
 
 logger = getLogger(__name__)
 
@@ -57,105 +52,16 @@ def export_csv_ordered_content(queryset: PageQuerySet, response: HttpResponse) -
     OrderedSetsExportWriter(export_rows).write_csv(response)
 
 
-def import_ordered_sets(file, filetype, progress_queue, purge=False):
-    def create_ordered_set_from_row(index, row):
-        set_name = row["Name"]
+def import_ordered_sets(file: File, filetype: str, progress_queue: Queue) -> None:
+    """
+    Import given ordered content file in the configured format with the configured importer.
 
-        ordered_set = OrderedContentSet.objects.filter(name=set_name).first()
-        if not ordered_set:
-            ordered_set = OrderedContentSet(name=set_name)
+    :param file: The file to be imported, as a django.core.files.base.File.
+    :param filetype: The type of the file, e.g. 'CSV' or 'XLSX'.
+    :param progress_queue: A queue.Queue to put progress information on.
+    """
 
-        ordered_set.profile_fields = []
-        for field in [f.strip() for f in (row["Profile Fields"] or "").split(",")]:
-            if not field or field == "-":
-                continue
-            [field_name, field_value] = field.split(":")
-            ordered_set.profile_fields.append((field_name, field_value))
+    from .import_ordered_content_sets import OrderedContentSetImporter
 
-        ordered_set.pages = []
-
-        times = [p.strip() for p in row["Time"].split(",")]
-        units = [p.strip() for p in row["Unit"].split(",")]
-        before_or_afters = [p.strip() for p in row["Before Or After"].split(",")]
-        page_slugs = [p.strip() for p in row["Page Slugs"].split(",")]
-        contact_fields = row["Contact Field"].split(",")
-        contact_fields = (
-            [p.strip() for p in contact_fields]
-            if len(contact_fields) > 1
-            else [contact_fields[0]] * len(times)
-        )
-        if (
-            len(times) != 0
-            and len(times) != len(units)
-            or len(times) != len(before_or_afters)
-            or len(times) != len(page_slugs)
-            or len(times) != len(contact_fields)
-        ):
-            raise ImportException(
-                f"Row {row['Name']} has {len(times)} times, {len(units)} units, {len(before_or_afters)} before_or_afters, {len(page_slugs)} page_slugs and {len(contact_fields)} contact_fields and they should all be equal.",
-                index,
-            )
-        for idx, page_slug in enumerate(page_slugs):
-            if not page_slug or page_slug == "-":
-                continue
-            page = ContentPage.objects.filter(slug=page_slug).first()
-            time = times[idx]
-            unit = units[idx]
-            before_or_after = before_or_afters[idx]
-            contact_field = contact_fields[idx]
-            if page:
-                ordered_set.pages.append(
-                    (
-                        "pages",
-                        {
-                            "contentpage": page,
-                            "time": time or "",
-                            "unit": unit or "",
-                            "before_or_after": before_or_after or "",
-                            "contact_field": contact_field or "",
-                        },
-                    )
-                )
-            else:
-                logger.warning(f"Content page not found for slug '{page_slug}'")
-
-        ordered_set.save()
-        return ordered_set
-
-    file = file.read()
-    lines = []
-    if filetype == "XLSX":
-        wb = load_workbook(filename=BytesIO(file))
-        ws = wb.worksheets[0]
-        ws.delete_rows(1)
-        for row in ws.iter_rows(values_only=True):
-            row_dict = {
-                "Name": row[0],
-                "Profile Fields": row[1],
-                "Page Slugs": row[2],
-                "Time": row[3],
-                "Unit": row[4],
-                "Before Or After": row[5],
-                "Contact Field": row[6],
-            }
-            lines.append(row_dict)
-    else:
-        if isinstance(file, bytes):
-            try:
-                file = file.decode("utf-8")
-            except UnicodeDecodeError:
-                file = file.decode("latin-1")
-
-        reader = csv.DictReader(io.StringIO(file))
-        for dictionary in reader:
-            lines.append(dictionary)
-
-    # 10% progress for loading file
-    progress_queue.put_nowait(10)
-
-    for index, row in enumerate(lines):
-        os = create_ordered_set_from_row(index, row)
-        if not os:
-            print(f"Ordered Content Set not created for row {index + 1}")
-        # 10-100% for loading ordered content sets
-        progress_queue.put_nowait(10 + index * 90 / len(lines))
+    importer = OrderedContentSetImporter(file, filetype, progress_queue)
+    importer.perform_import()

--- a/home/import_ordered_content_sets.py
+++ b/home/import_ordered_content_sets.py
@@ -32,7 +32,7 @@ class OrderedContentSetImporter:
         self.progress_queue = progress_queue
 
     def _get_or_init_ordered_content_set(
-        self, row: dict, set_name: str
+        self, row: dict[str, str], set_name: str
     ) -> OrderedContentSet:
         """
         Get or initialize an instance of OrderedContentSet from a row of a CSV file.
@@ -67,12 +67,12 @@ class OrderedContentSetImporter:
     def _validate_extracted_values(
         self,
         index: int,
-        row: dict,
-        times: list,
-        units: list,
-        before_or_afters: list,
-        page_slugs: list,
-        contact_fields: list,
+        row: dict[str, str],
+        times: list[str],
+        units: list[str],
+        before_or_afters: list[str],
+        page_slugs: list[str],
+        contact_fields: list[str],
     ) -> None:
         """
         Validate that the extracted values (times, units, before_or_afters, page_slugs, contact_fields) from a row of the file have the same length.
@@ -94,11 +94,11 @@ class OrderedContentSetImporter:
     def _create_pages(
         self,
         ordered_set: OrderedContentSet,
-        times: list,
-        units: list,
-        before_or_afters: list,
-        page_slugs: list,
-        contact_fields: list,
+        times: list[str],
+        units: list[str],
+        before_or_afters: list[str],
+        page_slugs: list[str],
+        contact_fields: list[str],
     ) -> None:
         """
         Given the extracted values from a row of the file, create the corresponding ordered content set pages.
@@ -136,7 +136,9 @@ class OrderedContentSetImporter:
             else:
                 logger.warning(f"Content page not found for slug '{page_slug}'")
 
-    def _create_ordered_set_from_row(self, index: int, row: dict) -> OrderedContentSet:
+    def _create_ordered_set_from_row(
+        self, index: int, row: dict[str, str]
+    ) -> OrderedContentSet:
         """
         Create an ordered content set from a single row of the file.
 
@@ -170,7 +172,7 @@ class OrderedContentSetImporter:
         ordered_set.save()
         return ordered_set
 
-    def perform_import(self):
+    def perform_import(self) -> None:
         """
         Import ordered content sets from a file.
 

--- a/home/import_ordered_content_sets.py
+++ b/home/import_ordered_content_sets.py
@@ -144,18 +144,14 @@ class OrderedContentSetImporter:
             if page.page_slug and page.page_slug != "-":
                 content_page = ContentPage.objects.filter(slug=page.page_slug).first()
                 if content_page:
-                    ordered_set.pages.append(
-                        (
-                            "pages",
-                            {
-                                "contentpage": content_page,
-                                "time": page.time or "",
-                                "unit": page.unit or "",
-                                "before_or_after": page.before_or_after or "",
-                                "contact_field": page.contact_field or "",
-                            },
-                        )
-                    )
+                    os_page = {
+                        "contentpage": content_page,
+                        "time": page.time or "",
+                        "unit": page.unit or "",
+                        "before_or_after": page.before_or_after or "",
+                        "contact_field": page.contact_field or "",
+                    }
+                    ordered_set.pages.append(("pages", os_page))
                 else:
                     raise ImportException(
                         f"Content page not found for slug '{page.page_slug}'"

--- a/home/import_ordered_content_sets.py
+++ b/home/import_ordered_content_sets.py
@@ -1,0 +1,222 @@
+import csv
+import io
+from io import BytesIO
+from logging import getLogger
+from queue import Queue
+
+from django.core.files.base import File  # type: ignore
+from openpyxl import load_workbook
+
+from home.import_helpers import ImportException
+from home.models import ContentPage, OrderedContentSet
+
+logger = getLogger(__name__)
+
+
+class OrderedContentSetImporter:
+    def __init__(
+        self,
+        file: File,
+        file_type: str,
+        progress_queue: Queue[int],
+    ):
+        """
+        Initialize an instance of OrderedContentSetImporter.
+
+        :param file: The file to be imported, as a django.core.files.base.File.
+        :param file_type: The type of the file, e.g. 'CSV' or 'XLSX'.
+        :param progress_queue: A queue.Queue to put progress information on.
+        """
+        self.file = file
+        self.filetype = file_type
+        self.progress_queue = progress_queue
+
+    def _get_or_init_ordered_content_set(
+        self, row: dict, set_name: str
+    ) -> OrderedContentSet:
+        """
+        Get or initialize an instance of OrderedContentSet from a row of a CSV file.
+
+        :param row: The row of the CSV file, as a dict.
+        :param set_name: The name of the ordered content set.
+        :return: An instance of OrderedContentSet.
+        """
+        ordered_set = OrderedContentSet.objects.filter(name=set_name).first()
+        if not ordered_set:
+            ordered_set = OrderedContentSet(name=set_name)
+
+        ordered_set.profile_fields = []
+        for field in [f.strip() for f in (row["Profile Fields"] or "").split(",")]:
+            if not field or field == "-":
+                continue
+            [field_name, field_value] = field.split(":")
+            ordered_set.profile_fields.append((field_name, field_value))
+
+        ordered_set.pages = []
+        return ordered_set
+
+    def _csv_to_list(self, column: str) -> list[str]:
+        """
+        Return a list of strings parsed from a column of a CSV row.
+
+        :param column: The column to parse.
+        :return: A list of strings, split from the value of row[column].
+        """
+        return [p.strip() for p in column.split(",")]
+
+    def _validate_extracted_values(
+        self,
+        index: int,
+        row: dict,
+        times: list,
+        units: list,
+        before_or_afters: list,
+        page_slugs: list,
+        contact_fields: list,
+    ) -> None:
+        """
+        Validate that the extracted values (times, units, before_or_afters, page_slugs, contact_fields) from a row of the file have the same length.
+        If not, raise an ImportException.
+        """
+
+        if (
+            len(times) != 0
+            and len(times) != len(units)
+            or len(times) != len(before_or_afters)
+            or len(times) != len(page_slugs)
+            or len(times) != len(contact_fields)
+        ):
+            raise ImportException(
+                f"Row {row['Name']} has {len(times)} times, {len(units)} units, {len(before_or_afters)} before_or_afters, {len(page_slugs)} page_slugs and {len(contact_fields)} contact_fields and they should all be equal.",
+                index,
+            )
+
+    def _create_pages(
+        self,
+        ordered_set: OrderedContentSet,
+        times: list,
+        units: list,
+        before_or_afters: list,
+        page_slugs: list,
+        contact_fields: list,
+    ) -> None:
+        """
+        Given the extracted values from a row of the file, create the corresponding ordered content set pages.
+
+        Note that this adds the pages to the OrderedContentSet object, hence there is no return value.
+
+        :param ordered_set: The ordered content set to add the pages to.
+        :param times: The times extracted from the row.
+        :param units: The units extracted from the row.
+        :param before_or_afters: The before or afters extracted from the row.
+        :param page_slugs: The page slugs extracted from the row.
+        :param contact_fields: The contact fields extracted from the row.
+        """
+        for idx, page_slug in enumerate(page_slugs):
+            if not page_slug or page_slug == "-":
+                continue
+            page = ContentPage.objects.filter(slug=page_slug).first()
+            time = times[idx]
+            unit = units[idx]
+            before_or_after = before_or_afters[idx]
+            contact_field = contact_fields[idx]
+            if page:
+                ordered_set.pages.append(
+                    (
+                        "pages",
+                        {
+                            "contentpage": page,
+                            "time": time or "",
+                            "unit": unit or "",
+                            "before_or_after": before_or_after or "",
+                            "contact_field": contact_field or "",
+                        },
+                    )
+                )
+            else:
+                logger.warning(f"Content page not found for slug '{page_slug}'")
+
+    def _create_ordered_set_from_row(self, index: int, row: dict) -> OrderedContentSet:
+        """
+        Create an ordered content set from a single row of the file.
+
+        :param index: The row number of the row being processed.
+        :param row: The row of the file as a dictionary.
+        :return: An instance of OrderedContentSet.
+        :raises ImportException: If time, units, before_or_afters, page_slugs and contact_fields are not all equal length.
+        """
+        ordered_set = self._get_or_init_ordered_content_set(row, row["Name"])
+
+        times = self._csv_to_list(row["Time"])
+        units = self._csv_to_list(row["Unit"])
+        before_or_afters = self._csv_to_list(row["Before Or After"])
+        page_slugs = self._csv_to_list(row["Page Slugs"])
+        # backwards compatiblilty if there's only one contact field
+        contact_fields = row["Contact Field"].split(",")
+        contact_fields = (
+            [p.strip() for p in contact_fields]
+            if len(contact_fields) > 1
+            else [contact_fields[0]] * len(times)
+        )
+
+        self._validate_extracted_values(
+            index, row, times, units, before_or_afters, page_slugs, contact_fields
+        )
+
+        self._create_pages(
+            ordered_set, times, units, before_or_afters, page_slugs, contact_fields
+        )
+
+        ordered_set.save()
+        return ordered_set
+
+    def perform_import(self):
+        """
+        Import ordered content sets from a file.
+
+        This method reads the file associated with the importer, processes its
+        content based on the specified file type (XLSX or CSV), and creates
+        ordered content sets by extracting relevant information from each row.
+        The progress of the import operation is reported via a queue.
+
+        Raises:
+            ImportException: If any inconsistencies are found in the data
+            row while creating ordered content sets.
+        """
+        file = self.file.read()
+        lines = []
+        if self.filetype == "XLSX":
+            wb = load_workbook(filename=BytesIO(file))
+            ws = wb.worksheets[0]
+            ws.delete_rows(1)
+            for row in ws.iter_rows(values_only=True):
+                row_dict = {
+                    "Name": row[0],
+                    "Profile Fields": row[1],
+                    "Page Slugs": row[2],
+                    "Time": row[3],
+                    "Unit": row[4],
+                    "Before Or After": row[5],
+                    "Contact Field": row[6],
+                }
+                lines.append(row_dict)
+        else:
+            if isinstance(file, bytes):
+                try:
+                    file = file.decode("utf-8")
+                except UnicodeDecodeError:
+                    file = file.decode("latin-1")
+
+            reader = csv.DictReader(io.StringIO(file))
+            for dictionary in reader:
+                lines.append(dictionary)
+
+        # 10% progress for loading file
+        self.progress_queue.put_nowait(10)
+
+        for index, row in enumerate(lines):
+            os = self._create_ordered_set_from_row(index, row)
+            if not os:
+                print(f"Ordered Content Set not created for row {index + 1}")
+            # 10-100% for loading ordered content sets
+            self.progress_queue.put_nowait(10 + index * 90 / len(lines))

--- a/home/import_ordered_content_sets.py
+++ b/home/import_ordered_content_sets.py
@@ -1,5 +1,6 @@
 import csv
 import io
+from dataclasses import dataclass
 from io import BytesIO
 from logging import getLogger
 from queue import Queue
@@ -13,20 +14,13 @@ from home.models import ContentPage, OrderedContentSet
 logger = getLogger(__name__)
 
 
+@dataclass
 class OrderedContentSetPage:
-    def __init__(
-        self,
-        time: str,
-        unit: str,
-        before_or_after: str,
-        page_slug: str,
-        contact_field: str,
-    ):
-        self.time = time
-        self.unit = unit
-        self.before_or_after = before_or_after
-        self.page_slug = page_slug
-        self.contact_field = contact_field
+    time: str
+    unit: str
+    before_or_after: str
+    page_slug: str
+    contact_field: str
 
 
 class OrderedContentSetImporter:

--- a/home/import_ordered_content_sets.py
+++ b/home/import_ordered_content_sets.py
@@ -22,11 +22,11 @@ class OrderedContentSetPage:
         page_slug: str,
         contact_field: str,
     ):
-        self.times = time
-        self.units = unit
-        self.before_or_afters = before_or_after
-        self.page_slugs = page_slug
-        self.contact_fields = contact_field
+        self.time = time
+        self.unit = unit
+        self.before_or_after = before_or_after
+        self.page_slug = page_slug
+        self.contact_field = contact_field
 
 
 class OrderedContentSetImporter:
@@ -185,7 +185,7 @@ class OrderedContentSetImporter:
     def _set_progress(self, progress: int) -> None:
         self.progress_queue.put_nowait(progress)
 
-    def _get_xlsx_rows(self, file) -> list[dict[str, str]]:
+    def _get_xlsx_rows(self, file: File) -> list[dict[str, str]]:
         """
         Return a list of dictionaries representing the rows in the XLSX file.
 
@@ -197,18 +197,18 @@ class OrderedContentSetImporter:
         ws.delete_rows(1)
         for row in ws.iter_rows(values_only=True):
             row_dict = {
-                "Name": row[0],
-                "Profile Fields": row[1],
-                "Page Slugs": row[2],
-                "Time": row[3],
-                "Unit": row[4],
-                "Before Or After": row[5],
-                "Contact Field": row[6],
+                "Name": str(row[0]),
+                "Profile Fields": str(row[1]),
+                "Page Slugs": str(row[2]),
+                "Time": str(row[3]),
+                "Unit": str(row[4]),
+                "Before Or After": str(row[5]),
+                "Contact Field": str(row[6]),
             }
             lines.append(row_dict)
         return lines
 
-    def _get_csv_rows(self, file) -> list[dict[str, str]]:
+    def _get_csv_rows(self, file: File) -> list[dict[str, str]]:
         """
         Return a list of dictionaries representing the rows in the CSV file.
 

--- a/home/import_ordered_content_sets.py
+++ b/home/import_ordered_content_sets.py
@@ -84,21 +84,8 @@ class OrderedContentSetImporter:
         if len(contact_fields) == 1:
             contact_fields = [contact_fields[0]] * len(times)
 
-        if (
-            len(
-                {
-                    len(item)
-                    for item in [
-                        times,
-                        units,
-                        before_or_afters,
-                        page_slugs,
-                        contact_fields,
-                    ]
-                }
-            )
-            != 1
-        ):
+        fields = [times, units, before_or_afters, page_slugs, contact_fields]
+        if len({len(item) for item in fields}) != 1:
             raise ImportException(
                 f"Row {row['Name']} has {len(times)} times, {len(units)} units, {len(before_or_afters)} before_or_afters, {len(page_slugs)} page_slugs and {len(contact_fields)} contact_fields and they should all be equal.",
                 index,

--- a/home/import_ordered_content_sets.py
+++ b/home/import_ordered_content_sets.py
@@ -172,6 +172,9 @@ class OrderedContentSetImporter:
         ordered_set.save()
         return ordered_set
 
+    def _set_progress(self, progress: int) -> None:
+        self.progress_queue.put_nowait(progress)
+
     def perform_import(self) -> None:
         """
         Import ordered content sets from a file.
@@ -214,11 +217,11 @@ class OrderedContentSetImporter:
                 lines.append(dictionary)
 
         # 10% progress for loading file
-        self.progress_queue.put_nowait(10)
+        self._set_progress(10)
 
-        for index, row in enumerate(lines):
-            os = self._create_ordered_set_from_row(index, row)
+        for index, row in enumerate(lines):  # type: ignore
+            os = self._create_ordered_set_from_row(index, row)  # type: ignore
             if not os:
                 print(f"Ordered Content Set not created for row {index + 1}")
             # 10-100% for loading ordered content sets
-            self.progress_queue.put_nowait(10 + index * 90 / len(lines))
+            self._set_progress(10 + index * 90 // len(lines))

--- a/home/tests/import-export-data/ordered_content.csv
+++ b/home/tests/import-export-data/ordered_content.csv
@@ -1,2 +1,2 @@
 Name,Profile Fields,Page Slugs,Time,Unit,Before Or After,Contact Field
-Test Set,"gender:male, relationship:in_a_relationship",first_time_user,2,days,before,edd
+Test Set,"gender:male, relationship:in_a_relationship","first_time_user, first_time_user, first_time_user","2, 3, 4","days, months, years","before, before, after",edd

--- a/home/tests/import-export-data/ordered_content_broken.csv
+++ b/home/tests/import-export-data/ordered_content_broken.csv
@@ -1,0 +1,2 @@
+Name,Profile Fields,Page Slugs,Time,Unit,Before Or After,Contact Field
+Test Set,"gender:male, relationship:in_a_relationship","first_time_user, first_time_user, first_time_user","2, 4","days, years","before, before, after","edd, name, age"

--- a/home/tests/import-export-data/ordered_content_multiple_contact_fields.csv
+++ b/home/tests/import-export-data/ordered_content_multiple_contact_fields.csv
@@ -1,0 +1,2 @@
+Name,Profile Fields,Page Slugs,Time,Unit,Before Or After,Contact Field
+Test Set,"gender:male, relationship:in_a_relationship","first_time_user, first_time_user, first_time_user","2, 3, 4","days, months, years","before, before, after","edd, name, age"

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1187,7 +1187,7 @@ class TestImportExport:
 
     def test_import_ordered_content_sets_error(self, csv_impexp: ImportExport) -> None:
         """
-        Importing a broken CSV for ordered content sets shoud throw an exception
+        Importing a broken CSV for ordered content sets shoud throw an exception and give a detailed error message
         """
         csv_impexp.import_file("contentpage_required_fields.csv")
 

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1195,7 +1195,7 @@ class TestImportExport:
 
     def test_import_ordered_content_sets_error(self, csv_impexp: ImportExport) -> None:
         """
-        Importing a broken CSV for ordered content sets shoud throw an exception and give a detailed error message
+        Importing a broken CSV for ordered content sets should throw an exception and give a detailed error message
         """
         csv_impexp.import_file("contentpage_required_fields.csv")
 
@@ -1207,6 +1207,18 @@ class TestImportExport:
         assert e.value.message == [
             "Row Test Set has 2 times, 2 units, 3 before_or_afters, 3 page_slugs and 3 contact_fields and they should all be equal."
         ]
+
+    def test_import_ordered_content_sets_no_page_error(
+        self, csv_impexp: ImportExport
+    ) -> None:
+        """
+        Importing CSV for ordered content sets without pages should throw an error.
+        """
+        with pytest.raises(ImportException) as e:
+            content = csv_impexp.read_bytes("ordered_content.csv")
+            csv_impexp.import_ordered_sets(content)
+
+        assert e.value.message == ["Content page not found for slug 'first_time_user'"]
 
     def test_import_ordered_sets_csv(self, csv_impexp: ImportExport) -> None:
         """

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -457,8 +457,8 @@ class ImportExport:
         """
         import_content(BytesIO(content_bytes), self.format.upper(), Queue(), **kw)
 
-    def import_ordered_sets(self, content_bytes: bytes, purge: bool = False) -> None:
-        import_ordered_sets(BytesIO(content_bytes), self.format.upper(), Queue(), purge)
+    def import_ordered_sets(self, content_bytes: bytes) -> None:
+        import_ordered_sets(BytesIO(content_bytes), self.format.upper(), Queue())
 
     def read_bytes(self, path_str: str, path_base: Path = IMP_EXP_DATA_BASE) -> bytes:
         return (path_base / path_str).read_bytes()

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1185,6 +1185,21 @@ class TestImportExport:
             "Validation error: whatsapp_template_category - Select a valid choice. Marketing is not one of the available choices.",
         ]
 
+    def test_import_ordered_content_sets_error(self, csv_impexp: ImportExport) -> None:
+        """
+        Importing a broken CSV for ordered content sets shoud throw an exception
+        """
+        csv_impexp.import_file("contentpage_required_fields.csv")
+
+        with pytest.raises(ImportException) as e:
+            content = csv_impexp.read_bytes("ordered_content_broken.csv")
+            csv_impexp.import_ordered_sets(content)
+
+        assert e.value.row_num == 0
+        assert e.value.message == [
+            "Row Test Set has 2 times, 2 units, 3 before_or_afters, 3 page_slugs and 3 contact_fields and they should all be equal."
+        ]
+
     def test_import_ordered_sets_csv(self, csv_impexp: ImportExport) -> None:
         """
         Importing a CSV file with ordered content sets should not break
@@ -1197,12 +1212,27 @@ class TestImportExport:
 
         assert ordered_set.name == "Test Set"
         pages = unwagtail(ordered_set.pages)
-        assert len(pages) == 1
+        assert len(pages) == 3
+
         page = pages[0][1]
         assert page["contentpage"].slug == "first_time_user"
         assert page["time"] == "2"
         assert page["unit"] == "days"
         assert page["before_or_after"] == "before"
+        assert page["contact_field"] == "edd"
+
+        page = pages[1][1]
+        assert page["contentpage"].slug == "first_time_user"
+        assert page["time"] == "3"
+        assert page["unit"] == "months"
+        assert page["before_or_after"] == "before"
+        assert page["contact_field"] == "edd"
+
+        page = pages[2][1]
+        assert page["contentpage"].slug == "first_time_user"
+        assert page["time"] == "4"
+        assert page["unit"] == "years"
+        assert page["before_or_after"] == "after"
         assert page["contact_field"] == "edd"
         assert unwagtail(ordered_set.profile_fields) == [
             ("gender", "male"),
@@ -1348,7 +1378,9 @@ class TestExport:
         """
         csv_impexp.import_file("contentpage_required_fields.csv")
 
-        imported_content = csv_impexp.import_ordered_file("ordered_content.csv")
+        imported_content = csv_impexp.import_ordered_file(
+            "ordered_content_multiple_contact_fields.csv"
+        )
 
         exported_content = csv_impexp.export_ordered_content()
 

--- a/home/views.py
+++ b/home/views.py
@@ -241,9 +241,7 @@ class OrderedContentSetUploadThread(UploadThread):
 
     def run(self):
         try:
-            import_ordered_sets(
-                self.file, self.file_type, self.progress_queue, self.purge
-            )
+            import_ordered_sets(self.file, self.file_type, self.progress_queue)
         except Exception:
             self.result_queue.put((messages.ERROR, "Ordered content set import failed"))
             logger.exception("Ordered content set import failed")

--- a/home/views.py
+++ b/home/views.py
@@ -247,6 +247,16 @@ class OrderedContentSetUploadThread(UploadThread):
         except Exception:
             self.result_queue.put((messages.ERROR, "Ordered content set import failed"))
             logger.exception("Ordered content set import failed")
+        except ImportException as e:
+            self.result_queue.put(
+                (
+                    messages.ERROR,
+                    [
+                        f"Ordered content set import failed on row {e.row_num}: {msg}"
+                        for msg in e.message
+                    ],
+                )
+            )
         else:
             self.result_queue.put(
                 (messages.SUCCESS, "Ordered content set import successful")


### PR DESCRIPTION
## Purpose
When we import Ordered Sets we aren't taking into account that the columns "Time", "Unit", "Before or After", or "Contact Page" could contain a comma separated string of values.

## Solution
This PR takes the above into account, and also adds some validation for if the number of items in those columns don't match up.

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

