### PR TITLE
Add Ordered Content Set filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!--
 ## Unreleased
+### Added
+- Filter ordered content sets by profile field values.
+
 ### Removed
 - Removed word embeddings search (`s` query parameter in API)
 

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -1171,12 +1171,262 @@ class TestOrderedContentSetAPI:
             "value": "female",
         }
 
-    def test_orderedcontent_endpoint_filter_on_gender_profile_field(self, uclient):
+    def test_orderedcontent_endpoint_filter_male_on_gender_profile_field(self, uclient):
         """
         The correct ordered content sets are returned if the filter is applied.
         """
-        url = "/api/v2/orderedcontent/?gender=Male"
-        # it should return no content because there is no content matching this filter
+        url = "/api/v2/orderedcontent/?gender=male"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 0
+
+    def test_orderedcontent_endpoint_filter_female_on_gender_profile_field(
+        self, uclient
+    ):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("gender", "male"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?gender=female"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 2
+
+    def test_orderedcontent_endpoint_filter_on_age_profile_field(self, uclient):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("age", "18 - 25"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?age=18 - 25"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 1
+
+    def test_orderedcontent_endpoint_filter_incorrect_age_profile_field(self, uclient):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("age", "18 - 25"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?age=7 - 8"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 0
+
+    def test_orderedcontent_endpoint_filter_on_relationship_profile_field(
+        self, uclient
+    ):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("relationship", "single"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?relationship=single"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 1
+
+    def test_orderedcontent_endpoint_filter_incorrect_relationship_profile_field(
+        self, uclient
+    ):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("relationship", "single"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?relationship=in a relationship"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 0
+
+    def test_orderedcontent_endpoint_filter_gender_age_profile_field(self, uclient):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("age", "18 - 25"))
+        ordered_content_set.profile_fields.append(("gender", "male"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?gender=male&age=18 - 25"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 1
+
+    def test_orderedcontent_endpoint_filter_incorrect_gender_age_profile_field(
+        self, uclient
+    ):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("age", "18 - 25"))
+        ordered_content_set.profile_fields.append(("gender", "male"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?gender=male&age=4 - 5"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 0
+
+    def test_orderedcontent_endpoint_filter_gender_relationship_profile_field(
+        self, uclient
+    ):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("relationship", "single"))
+        ordered_content_set.profile_fields.append(("gender", "male"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?gender=male&relationship=single"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 1
+
+    def test_orderedcontent_endpoint_filter_incorrect_gender_relationship_profile_field(
+        self, uclient
+    ):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("relationship", "single"))
+        ordered_content_set.profile_fields.append(("gender", "male"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?gender=male&relationship=in a relationship"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 0
+
+    def test_orderedcontent_endpoint_filter_age_relationship_profile_field(
+        self, uclient
+    ):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("relationship", "single"))
+        ordered_content_set.profile_fields.append(("age", "18 - 25"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?age=18 - 25&relationship=single"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 1
+
+    def test_orderedcontent_endpoint_filter_incorrect_age_relationship_profile_field(
+        self, uclient
+    ):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("relationship", "single"))
+        ordered_content_set.profile_fields.append(("age", "4 - 5"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?age=4 - 5&relationship=in a relationship"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 0
+
+    def test_orderedcontent_endpoint_filter_gender_age_relationship_profile_field(
+        self, uclient
+    ):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("gender", "male"))
+        ordered_content_set.profile_fields.append(("relationship", "single"))
+        ordered_content_set.profile_fields.append(("age", "18 - 25"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?gender=male&age=18 - 25&relationship=single"
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 1
+
+    def test_orderedcontent_endpoint_filter_incorrect_gender_age_relationship_profile_field(
+        self, uclient
+    ):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        ordered_content_set = OrderedContentSet(name="Test set")
+        ordered_content_set.pages.append(("pages", {"contentpage": self.page1}))
+        ordered_content_set.profile_fields.append(("gender", "male"))
+        ordered_content_set.profile_fields.append(("relationship", "single"))
+        ordered_content_set.profile_fields.append(("age", "4 - 5"))
+        ordered_content_set.save()
+        ordered_content_set.save_revision().publish()
+
+        url = "/api/v2/orderedcontent/?gender=female&age=4 - 5&relationship=in a relationship"
         response = uclient.get(url)
         content = json.loads(response.content)
 

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -1171,6 +1171,18 @@ class TestOrderedContentSetAPI:
             "value": "female",
         }
 
+    def test_orderedcontent_endpoint_filter_on_gender_profile_field(self, uclient):
+        """
+        The correct ordered content sets are returned if the filter is applied.
+        """
+        url = "/api/v2/orderedcontent/?gender=Male"
+        # it should return no content because there is no content matching this filter
+        response = uclient.get(url)
+        content = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert content["count"] == 0
+
     def test_orderedcontent_endpoint_without_drafts(self, uclient):
         """
         Unpublished ordered content sets are not returned if the qa param is not set.


### PR DESCRIPTION
## Purpose
For push messages we need to filter which content sets should be used according to a user's contact fields (gender, age, relationship - the profile field values). We can do this on the FE but that means we have to request ALL the content sets and filter it in Journeys, so this PR offloads that task to CMS.

## Solution
This adds gender, age, and relationship as query params for Ordered Content Sets, and filters results accordingly.

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

