### PR TITLE
Fix import errors for fields with whitespace-only values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API: Fix detail URL in Pages API
 - Forms: Added model import validation so that required fields are flagged on import
 - API: Return all pages if tag keyword is specified without tags
+- Importing certain ContentPage fields with whitespace-only values will no longer throw unhandled exceptions
 
 ### Security
 - Updated sentry-sdk from 1.44.1 to 2.8.0

--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -689,15 +689,25 @@ class ContentRow:
     @classmethod
     def from_flat(cls, row: dict[str, str], row_num: int) -> "ContentRow":
         class_fields = {field.name for field in fields(cls)}
+        # NOTES:
+        # * We strip leading and trailing whitespace off the field values
+        #   because that lets us be a little more permissive with inputs, but
+        #   we leave the field keys as-is because otherwise we may end up with
+        #   duplicates for keys with whitespace differences.
+        # * It's also important to strip whitespace in both the output dict and
+        #   the emptiness check, otherwise whitespace-only fields will be
+        #   non-mpty here but empty below.
+        # * We need to check `value` before `value.strip()` because we may get
+        #   `None` values for missing fields.
         row = {
-            key.strip(): value.strip()
+            key: value.strip()
             for key, value in row.items()
-            if value and key in class_fields
+            if key in class_fields and value and value.strip()
         }
         if "slug" not in row:
             raise ImportException("Missing slug value", row_num)
         return cls(
-            page_id=int(row.pop("page_id")) if row.get("page_id") else None,
+            page_id=to_int_or_none(row.pop("page_id", None)),
             variation_title=deserialise_dict(row.pop("variation_title", "")),
             tags=deserialise_list(row.pop("tags", "")),
             quick_replies=deserialise_list(row.pop("quick_replies", "")),
@@ -710,7 +720,7 @@ class ContentRow:
                 else []
             ),
             list_items=deserialise_list(row.pop("list_items", "")),
-            footer=row.pop("footer") if row.get("footer") else "",
+            footer=row.pop("footer", ""),
             **row,
         )
 
@@ -789,3 +799,7 @@ def JSON_loader(row_num: int, value: str) -> list[dict[str, Any]]:
         raise ImportException(f"Bad JSON button, you have: {value}", row_num)
 
     return button
+
+
+def to_int_or_none(val: str | None) -> int | None:
+    return int(val) if val else None

--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -696,7 +696,7 @@ class ContentRow:
         #   duplicates for keys with whitespace differences.
         # * It's also important to strip whitespace in both the output dict and
         #   the emptiness check, otherwise whitespace-only fields will be
-        #   non-mpty here but empty below.
+        #   non-empty here but empty below.
         # * We need to check `value` before `value.strip()` because we may get
         #   `None` values for missing fields.
         row = {

--- a/home/tests/import-export-data/whitespace-only-fields.csv
+++ b/home/tests/import-export-data/whitespace-only-fields.csv
@@ -1,0 +1,3 @@
+Structure,Message,page_id,slug,parent,web_title,web_subtitle,web_body,whatsapp_title,whatsapp_body,variation_body,variation_title,next_prompt,messenger_title,messenger_body,viber_title,viber_body,tags,quick_replies,triggers,locale,image_link,doc_link,media_link,footer,related_pages,footer
+Menu 1,0, ,main-menu,,test,,,,,,,,,,,,,,,English,,,,
+Sub 1.1.1,1,,content-page,,Web Title 1,Web subtitle 1,web body,Whatsapp Title 1,"First whatsapp message",,,,,,,,"tag1,tag2",,,English,,,, ,

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1071,6 +1071,15 @@ class TestImportExport:
             "Validation error: footer - Ensure this value has at most 60 characters (it has 110)."
         ]
 
+    @pytest.mark.xfail(reason="TODO: Fix this.")
+    def test_fields_containing_only_whitespace(self, csv_impexp: ImportExport) -> None:
+        """
+        A page_id or footer containing only whitespace is not an error.
+
+        NOTE: This test passes if no exception is raised.
+        """
+        csv_impexp.import_file("whitespace-only-fields.csv")
+
     def test_list_items_maximum_num(self, csv_impexp: ImportExport) -> None:
         """
         Importing an CSV file with list_items and and list items characters exceeding maximum charactercount

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1071,7 +1071,6 @@ class TestImportExport:
             "Validation error: footer - Ensure this value has at most 60 characters (it has 110)."
         ]
 
-    @pytest.mark.xfail(reason="TODO: Fix this.")
     def test_fields_containing_only_whitespace(self, csv_impexp: ImportExport) -> None:
         """
         A page_id or footer containing only whitespace is not an error.


### PR DESCRIPTION
## Purpose
Certain ContentPage fields are processed during import in a way that could cause problems if their value consists entirely of whitespace. This needs to be fixed.

#### Checklist
- [X] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

