### PR TITLE
Submit Buttons when creating a template

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -807,13 +807,22 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
         return self.quick_reply_items.all().values_list("tag__name", flat=True)
 
     @property
+    def whatsapp_template_buttons(self):
+        # If Buttons and quick replies are present then Buttons are used
+        first_msg = self.whatsapp_body.raw_data[0]["value"]
+        if "buttons" in first_msg and first_msg["buttons"]:
+            buttons = [b["value"]["title"] for b in first_msg["buttons"]]
+            return buttons
+        return sorted(self.quick_reply_buttons)
+
+    @property
     def whatsapp_template_fields(self):
         """
         Returns a tuple of fields that can be used to determine template equality
         """
         return (
             self.whatsapp_template_body,
-            sorted(self.quick_reply_buttons),
+            self.whatsapp_template_buttons,
             self.is_whatsapp_template,
             self.whatsapp_template_image,
             self.whatsapp_template_category,
@@ -850,7 +859,7 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
             self.whatsapp_template_body,
             str(self.whatsapp_template_category),
             self.locale,
-            sorted(self.quick_reply_buttons),
+            self.whatsapp_template_buttons,
             self.whatsapp_template_image,
             self.whatsapp_template_example_values,
         )

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -180,6 +180,43 @@ class ContentPageTests(TestCase):
 
     @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
     @mock.patch("home.models.create_whatsapp_template")
+    def test_template_created_with_proper_buttons_not_quick_replies(self, mock_create_whatsapp_template):
+        home_page = HomePage.objects.first()
+        main_menu = PageBuilder.build_cpi(home_page, "main-menu", "Main Menu")
+        page_with_button = PageBuilder.build_cp(
+            parent=main_menu,
+            slug="page2",
+            title="Page2",
+            bodies=[
+                WABody(
+                    "Page2",
+                    [
+                        WABlk(
+                            "Page2 WA Body",
+                            buttons=[
+                                PageBtn("Home", page=main_menu),
+                                PageBtn("Button 1", page=main_menu)
+                            ],
+                        )
+                    ],
+                )
+            ],
+            whatsapp_template_name="page2-template",
+            quick_replies = ["Menu", "Button 2"]
+        )
+        en = Locale.objects.get(language_code="en")
+        mock_create_whatsapp_template.assert_called_with(
+            f"page2_{page_with_button.get_latest_revision().id}",
+            "Page2 WA Body",
+            "UTILITY",
+            en,
+            ["Home", "Button 1"],
+            None,
+            [],
+        )
+
+    @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
+    @mock.patch("home.models.create_whatsapp_template")
     def test_template_create_with_example_values_on_save(
         self, mock_create_whatsapp_template
     ):

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -140,7 +140,10 @@ class ContentPageTests(TestCase):
                     [
                         WABlk(
                             "Page2 WA Body",
-                            buttons=[PageBtn("Import Export", page=main_menu)],
+                            buttons=[
+                                PageBtn("Menu", page=main_menu),
+                                PageBtn("Button 2", page=main_menu)
+                            ],
                         )
                     ],
                 )
@@ -150,11 +153,11 @@ class ContentPageTests(TestCase):
         )
         en = Locale.objects.get(language_code="en")
         mock_create_whatsapp_template.assert_called_with(
-            f"wa_title_{page_with_button.get_latest_revision().id}",
-            "Test WhatsApp Message 1",
+            f"page2_{page_with_button.get_latest_revision().id}",
+            "Page2 WA Body",
             "UTILITY",
             en,
-            ["button 1", "button 2"],
+            ["Menu", "Button 2"],
             None,
             [],
         )

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -113,14 +113,30 @@ class ContentPageTests(TestCase):
     @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
     @mock.patch("home.models.create_whatsapp_template")
     def test_template_create_with_quick_reply_buttons_on_save(self, mock_create_whatsapp_template):
-        page = create_page(is_whatsapp_template=True, has_quick_replies=True)
+        home_page = HomePage.objects.first()
+        main_menu = PageBuilder.build_cpi(home_page, "main-menu", "Main Menu")
+        page_with_button = PageBuilder.build_cp(
+            parent=main_menu,
+            slug="page2",
+            title="Page2",
+            bodies=[
+                WABody(
+                    "Page2",
+                    [
+                        WABlk("Page2 WA Body")
+                    ],
+                )
+            ],
+            whatsapp_template_name="page2-template",
+            quick_replies = ["Menu", "Button 2"]
+        )
         en = Locale.objects.get(language_code="en")
         mock_create_whatsapp_template.assert_called_with(
-            f"wa_title_{page.get_latest_revision().id}",
-            "Test WhatsApp Message 1",
+            f"page2_{page_with_button.get_latest_revision().id}",
+            "Page2 WA Body",
             "UTILITY",
             en,
-            ["button 1", "button 2"],
+            ["Button 2", "Menu"],
             None,
             [],
         )


### PR DESCRIPTION
## Purpose
Without this we are unable to use Buttons with template messages because they not submitted. However, we want to maintain the old functionality of submitting (sorted) quick replies if no buttons are provided. 

## Solution
On template submission we now submit Buttons if there are any present or Quick Replies if there are no Buttons. This means that existing pages should not have both Buttons and Quick Replies if the templates are expected to use the Quick Replies

#### Checklist
- [ /] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)

