### PR TITLE
Lowercase Unit and Before and After

### DIFF
--- a/home/import_ordered_content_sets.py
+++ b/home/import_ordered_content_sets.py
@@ -103,8 +103,8 @@ class OrderedContentSetImporter:
         return [
             OrderedContentSetPage(
                 time=time,
-                unit=unit,
-                before_or_after=before_or_after,
+                unit=unit.lower(),
+                before_or_after=before_or_after.lower(),
                 page_slug=page_slug,
                 contact_field=contact_field,
                 locale=row["locale"],

--- a/home/tests/import-export-data/ordered_content.csv
+++ b/home/tests/import-export-data/ordered_content.csv
@@ -1,3 +1,3 @@
 name,Profile Fields,Page Slugs,Time,Unit,Before Or After,Contact Field,Slug,Locale
 Test Set,"gender:male, relationship:in_a_relationship","first_time_user, first_time_user, first_time_user","2, 3, 4","days, months, minutes","before, before, after",edd,Test_Set,en
-Test Set PT,"gender:male, relationship:in_a_relationship",first_time_user,2,days,before,edd,test_set,pt
+Test Set PT,"gender:male, relationship:in_a_relationship",first_time_user,2,Days,Before,edd,test_set,pt


### PR DESCRIPTION
## Purpose
Ordered Content Sets should allow for upper and lowercased versions of unit and before and after fields.

## Solution
I lowercase the fields in the import

#### Checklist
- [ ] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)

