### PR TITLE
changed contentrepo UI naming from assessments to CMS forms

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -60,11 +60,11 @@ class CustomIndexView(SpreadsheetExportMixin, IndexView):
 
 class CustomIndexViewAssessment(SpreadsheetExportMixinAssessment, IndexViewAssessment):
     def get_template_names(self):
-        return ["wagtailsnippets/snippets/home/assessment/index.html"] 
+        return ["wagtailsnippets/snippets/home/assessment/index.html"]
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['model_opts'].verbose_name_plural = "CMS Form"
+        context["model_opts"].verbose_name_plural = "CMS Form"
         return context
 
 

--- a/home/views.py
+++ b/home/views.py
@@ -59,7 +59,13 @@ class CustomIndexView(SpreadsheetExportMixin, IndexView):
 
 
 class CustomIndexViewAssessment(SpreadsheetExportMixinAssessment, IndexViewAssessment):
-    pass
+    def get_template_names(self):
+        return ["wagtailsnippets/snippets/home/assessment/index.html"] 
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['model_opts'].verbose_name_plural = "CMS Form"
+        return context
 
 
 class CustomIndexViewWhatsAppTemplate(

--- a/home/views.py
+++ b/home/views.py
@@ -64,7 +64,7 @@ class CustomIndexViewAssessment(SpreadsheetExportMixinAssessment, IndexViewAsses
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["model_opts"].verbose_name_plural = "CMS Form"
+        context["model_opts"].verbose_name_plural = "CMS Forms"
         return context
 
 

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -300,7 +300,7 @@ class WhatsAppTemplateAdmin(SnippetViewSet):
 
 
 class AssessmentAdmin(SnippetViewSet):
-    menu_label = 'CMS Forms'
+    menu_label = "CMS Forms"
     model = Assessment
     add_to_admin_menu = True
     list_display = ("title", "slug", "version", "locale")

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -300,6 +300,7 @@ class WhatsAppTemplateAdmin(SnippetViewSet):
 
 
 class AssessmentAdmin(SnippetViewSet):
+    menu_label = 'CMS Forms'
     model = Assessment
     add_to_admin_menu = True
     list_display = ("title", "slug", "version", "locale")


### PR DESCRIPTION
## Purpose
Just to make it clear that CMS forms is no longer just for assessments we can rename the UI to CMS Forms. 

## Solution
Assessments was changed to "CMS forms"

#### Checklist
- [ ] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)

