### PR TITLE
Locale filtering to assessments API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Answer responses for Forms
 - Language_code field on imports and exports
 - Fix for assessment import for multiple languages
+- Add locale filtering to assessments API
 ### Removed
 - Locale field on exports 
 -->

--- a/contentrepo/urls.py
+++ b/contentrepo/urls.py
@@ -19,6 +19,10 @@ from drf_spectacular.views import (  # isort:skip
     SpectacularSwaggerView,
 )
 
+from rest_framework.routers import DefaultRouter
+
+router = DefaultRouter()
+router.register(r"cms-forms", home_views.AssessmentListViewSet, basename="cms-form")
 
 custom_v2router = routers.DefaultRouter()
 custom_v2router.register("ratings", home_views.ContentPageRatingViewSet)
@@ -47,8 +51,8 @@ urlpatterns = [
         name="redoc",
     ),
     path("api/whatsapptemplates/", menu_views.randommenu, name="whatsapptemplate"),
+    path("api/v2/", include(router.urls)),
 ]
-
 
 if settings.DEBUG:
     from django.conf.urls.static import static

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -9,7 +9,7 @@ from wagtail.api.v2.serializers import (
 )
 from wagtail.api.v2.utils import get_object_detail_url
 
-from home.models import ContentPage, ContentPageRating, PageView
+from home.models import Assessment, ContentPage, ContentPageRating, PageView
 
 
 class TitleField(serializers.Field):
@@ -623,6 +623,10 @@ class QuestionField(serializers.Field):
         return questions
 
 
-class AssessmentSerializer(BaseSerializer):
+class AssessmentSerializer(serializers.ModelSerializer):
     locale = PageLocaleField(read_only=True)
     questions = QuestionField(read_only=True)
+
+    class Meta:
+        model = Assessment
+        fields = "__all__"


### PR DESCRIPTION
## Purpose
Add locale filtering on assessment API_

## Solution
_The assessment page is a Snippet and Snippets, by default, don't have a built-in locale field like Wagtail pages so we had to explicitly add locale support and then handle the filtering in the API view.
The view set AssessmentListViewSet handles locale filtering for assessments. 
A custom path was used for the endpoint to avoid conflicts with the existing ones. 
Ex, pages remains as /api/v2/pages whereas assessments is registered under a new path /api/v2/cms-forms/?locale=en (with locale) _

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

