### PR TITLE
Add CMS locale filtering to assessment API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Language_code field on imports and exports
 - Remove whatsapp body hidden characters
 - Fix for assessment import for multiple languages
+- Add locale filtering to assessments API
 ### Removed
 - Locale field on exports
 -->

--- a/home/api.py
+++ b/home/api.py
@@ -324,6 +324,7 @@ class AssessmentViewSet(BaseAPIViewSet):
 
     def get_queryset(self):
         qa = self.request.query_params.get("qa")
+        locale_code = self.request.query_params.get("locale")
 
         if qa:
             # return the latest revision for each Assessment
@@ -355,12 +356,16 @@ class AssessmentViewSet(BaseAPIViewSet):
                 "last_published_at"
             )
 
+        if locale_code:
+            queryset = queryset.filter(locale__language_code=locale_code)
+
         tag = self.request.query_params.get("tag")
         if tag is not None:
             ids = []
             for t in AssessmentTag.objects.filter(tag__name__iexact=tag):
                 ids.append(t.content_object_id)
             queryset = queryset.filter(id__in=ids)
+
         return queryset
 
 


### PR DESCRIPTION
## Purpose
_Add locale filtering on assessment API_

## Solution
_The locale querystring was not filtering assessments as expected because the locale field in the Assessment model is a ForeignKey and the filtering logic was missing in the getqueryset method of the assessmentviewset_
_What worked was implementing the filtering logic in the get queryset method by checking if the locale query paramater exists and applying the filter._

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

