### PR TITLE
better validation for bad scores in CMS Forms

### DIFF
--- a/home/import_assessments.py
+++ b/home/import_assessments.py
@@ -455,8 +455,8 @@ def check_score_type(
                 "The score value allows only numbers",
                 row_num,
             )
-        
-        
+
+
 def deserialise_list(value: str) -> list[str]:
     """
     Takes a comma separated value serialised by the CSV library, and returns it as a

--- a/home/import_assessments.py
+++ b/home/import_assessments.py
@@ -370,6 +370,7 @@ class AssessmentRow:
         high_inflection = row.get("high_inflection")
         medium_inflection = row.get("medium_inflection")
         check_punctuation(high_inflection, medium_inflection, row_num)
+        check_score_type(high_inflection, medium_inflection, row_num)
 
         row = {
             key: value for key, value in row.items() if value and key in cls.fields()
@@ -433,6 +434,29 @@ def check_punctuation(
             )
 
 
+def check_score_type(
+    high_inflection: Any | None, medium_inflection: Any | None, row_num: int
+) -> None:
+    if high_inflection is not None and high_inflection != "":
+        try:
+            float(high_inflection)
+        except ValueError:
+            raise ImportAssessmentException(
+                "Invalid number format for high inflection. "
+                "The score value allows only numbers",
+                row_num,
+            )
+    if medium_inflection is not None and medium_inflection != "":
+        try:
+            float(medium_inflection)
+        except ValueError:
+            raise ImportAssessmentException(
+                "Invalid number format for high inflection. "
+                "The score value allows only numbers",
+                row_num,
+            )
+        
+        
 def deserialise_list(value: str) -> list[str]:
     """
     Takes a comma separated value serialised by the CSV library, and returns it as a

--- a/home/import_assessments.py
+++ b/home/import_assessments.py
@@ -451,7 +451,7 @@ def check_score_type(
             float(medium_inflection)
         except ValueError:
             raise ImportAssessmentException(
-                "Invalid number format for high inflection. "
+                "Invalid number format for medium inflection. "
                 "The score value allows only numbers",
                 row_num,
             )

--- a/home/tests/import-export-data/bad_form_score.csv
+++ b/home/tests/import-export-data/bad_form_score.csv
@@ -1,0 +1,3 @@
+title,question_type,tags,slug,version,locale,high_result_page,high_inflection,medium_result_page,medium_inflection,low_result_page,skip_threshold,skip_high_result_page,generic_error,question,explainer,error,min,max,answers,scores,answer_semantic_ids,question_semantic_id,answer_responses
+Titles,age_question,,titles,,en,,Text,,,,0.0,,Generic,What is your age,,,,,,,,test,
+title,age_question,,title,,en,,,,,,0.0,,yes,asg,,,,,,,,id,

--- a/home/tests/import-export-data/bad_medium_score.csv
+++ b/home/tests/import-export-data/bad_medium_score.csv
@@ -1,0 +1,3 @@
+title,question_type,tags,slug,version,locale,high_result_page,high_inflection,medium_result_page,medium_inflection,low_result_page,skip_threshold,skip_high_result_page,generic_error,question,explainer,error,min,max,answers,scores,answer_semantic_ids,question_semantic_id,answer_responses
+Titles,age_question,,titles,,en,,,,Text123,,0.0,,Generic,What is your age,,,,,,,,test,
+title,age_question,,title,,en,,,,,,0.0,,yes,asg,,,,,,,,id,

--- a/home/tests/test_assessment_import_export.py
+++ b/home/tests/test_assessment_import_export.py
@@ -592,6 +592,19 @@ class TestImportExport:
         )
         assert e.value.row_num == 2
 
+    def test_text_answers(self, csv_impexp: ImportExport) -> None:
+        """
+        Importing a CSV with text in the inflection values should return
+        an intuitive error message
+        """
+        with pytest.raises(ImportAssessmentException) as e:
+            csv_impexp.import_file("bad_form_score.csv")
+        assert (
+            e.value.message == "Invalid number format for high inflection. "
+            "The score value allows only numbers",
+        )
+        assert e.value.row_num == 2
+
 
 @pytest.mark.usefixtures("result_content_pages")
 @pytest.mark.django_db()

--- a/home/tests/test_assessment_import_export.py
+++ b/home/tests/test_assessment_import_export.py
@@ -601,7 +601,7 @@ class TestImportExport:
             csv_impexp.import_file("bad_form_score.csv")
         assert (
             e.value.message == "Invalid number format for high inflection. "
-            "The score value allows only numbers",
+            "The score value allows only numbers"
         )
         assert e.value.row_num == 2
 
@@ -614,7 +614,7 @@ class TestImportExport:
             csv_impexp.import_file("bad_medium_score.csv")
         assert (
             e.value.message == "Invalid number format for medium inflection. "
-            "The score value allows only numbers",
+            "The score value allows only numbers"
         )
         assert e.value.row_num == 2
 

--- a/home/tests/test_assessment_import_export.py
+++ b/home/tests/test_assessment_import_export.py
@@ -592,16 +592,29 @@ class TestImportExport:
         )
         assert e.value.row_num == 2
 
-    def test_invalid_scores(self, csv_impexp: ImportExport) -> None:
+    def test_invalid_high_score(self, csv_impexp: ImportExport) -> None:
         """
-        Importing a CSV with invalid data in the inflection values should return
-        an intuitive error message
+        Importing a CSV with invalid data in the high inflection value should
+        return an intuitive error message
         """
         with pytest.raises(ImportAssessmentException) as e:
             csv_impexp.import_file("bad_form_score.csv")
         assert (
             e.value.message == "Invalid number format for high inflection. "
-            "The score value allows only numbers"
+            "The score value allows only numbers",
+        )
+        assert e.value.row_num == 2
+
+    def test_invalid_medium_score(self, csv_impexp: ImportExport) -> None:
+        """
+        Importing a CSV with invalid data in the medium inflection value should
+        return an intuitive error message
+        """
+        with pytest.raises(ImportAssessmentException) as e:
+            csv_impexp.import_file("bad_medium_score.csv")
+        assert (
+            e.value.message == "Invalid number format for medium inflection. "
+            "The score value allows only numbers",
         )
         assert e.value.row_num == 2
 

--- a/home/tests/test_assessment_import_export.py
+++ b/home/tests/test_assessment_import_export.py
@@ -592,16 +592,16 @@ class TestImportExport:
         )
         assert e.value.row_num == 2
 
-    def test_text_answers(self, csv_impexp: ImportExport) -> None:
+    def test_invalid_scores(self, csv_impexp: ImportExport) -> None:
         """
-        Importing a CSV with text in the inflection values should return
+        Importing a CSV with invalid data in the inflection values should return
         an intuitive error message
         """
         with pytest.raises(ImportAssessmentException) as e:
             csv_impexp.import_file("bad_form_score.csv")
         assert (
             e.value.message == "Invalid number format for high inflection. "
-            "The score value allows only numbers",
+            "The score value allows only numbers"
         )
         assert e.value.row_num == 2
 


### PR DESCRIPTION
## Purpose
For the score field, if there's invalid text that we can't convert to a number, we just give a generic error. We should give a specific error with guidance on where and how the import file can be fixed.

## Solution
Invalid values for scores show appropriate error message to allow user to fix the import file.

#### Checklist
- [X] Added or updated unit tests


