### PR TITLE
Consistent labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove whatsapp body hidden characters
 - Fix for assessment import for multiple languages
 - Add locale filtering to assessments API
+- Consistent labelling on import forms
 ### Removed
 - Locale field on exports
 -->

--- a/home/forms.py
+++ b/home/forms.py
@@ -3,7 +3,7 @@ from wagtail.models import Locale
 
 
 class UploadFileForm(forms.Form):
-    FILE_CHOICES = (("CSV", "CSV file"), ("XLSX", "Excel File"))
+    FILE_CHOICES = (("CSV", "CSV File"), ("XLSX", "Excel File"))
     file = forms.FileField()
     file_type = forms.ChoiceField(choices=FILE_CHOICES)
 

--- a/home/tests/test_views.py
+++ b/home/tests/test_views.py
@@ -576,9 +576,7 @@ class TestUploadViews:
         file_upload = form.find("input", type="file", id="id_file")
         assert file_upload
 
-        assert find_options(form, "file_type") == ["CSV file", "Excel File"]
-        # TODO: consistency in the labeling, either both "file" or both "File"
-
+        assert find_options(form, "file_type") == ["CSV File", "Excel File"]
         assert find_options(soup, "purge") == ["No", "Yes"]
 
         all_locales = [locale.language_name for locale in Locale.objects.all()]
@@ -690,8 +688,7 @@ class TestOrderedContentImportView:
         file_upload = form.find("input", type="file", id="id_file")
         assert file_upload
 
-        assert find_options(form, "file_type") == ["CSV file", "Excel File"]
-
+        assert find_options(form, "file_type") == ["CSV File", "Excel File"]
         assert find_options(soup, "purge") == ["No", "Yes"]
 
 


### PR DESCRIPTION
## Purpose
To have consistent labelling on the import forms

## Solution
I updated the one label to have the same uppercase "File"

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

