### PR TITLE
Fix class_name warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix for assessment import for multiple languages
 - Add locale filtering to assessments API
 - Consistent labelling on import forms
+- Fix class_name warning: RemovedInWagtail60Warning
 ### Removed
 - Locale field on exports
 -->

--- a/contentrepo/templates/assessment_upload.html
+++ b/contentrepo/templates/assessment_upload.html
@@ -8,7 +8,7 @@
           <div class="col header-title">
             {% block h1 %}
               <h1>
-                {% icon name="openquote" class_name="header-title-icon" %}
+                {% icon name="openquote" classname="header-title-icon" %}
                   {% if loading %}
                     {% trans 'Uploading Content...' %}
                   {% else %}

--- a/contentrepo/templates/whatsapptemplate_upload.html
+++ b/contentrepo/templates/whatsapptemplate_upload.html
@@ -8,7 +8,7 @@
           <div class="col header-title">
             {% block h1 %}
               <h1>
-                {% icon name="openquote" class_name="header-title-icon" %}
+                {% icon name="openquote" classname="header-title-icon" %}
                   {% if loading %}
                     {% trans 'Uploading Content...' %}
                   {% else %}

--- a/home/tests/test_views.py
+++ b/home/tests/test_views.py
@@ -723,6 +723,7 @@ class TestAssessmentImportView:
 
         assert find_options(form, "file_type") == ["CSV File", "Excel File"]
         assert find_options(soup, "purge") == ["No", "Yes"]
+        assert find_options(form, "locale") == ["Import all languages", "English"]
 
 
 class TestWhatsAppTemplateImportView:
@@ -756,6 +757,7 @@ class TestWhatsAppTemplateImportView:
 
         assert find_options(form, "file_type") == ["CSV File", "Excel File"]
         assert find_options(soup, "purge") == ["No", "Yes"]
+        assert find_options(form, "locale") == ["Import all languages", "English"]
 
 
 @pytest.mark.django_db

--- a/home/tests/test_views.py
+++ b/home/tests/test_views.py
@@ -692,6 +692,72 @@ class TestOrderedContentImportView:
         assert find_options(soup, "purge") == ["No", "Yes"]
 
 
+class TestAssessmentImportView:
+    def test_import_assessment(self, admin_client):
+        """
+        The import page can be accessed at the expected url
+        """
+        response = admin_client.get("/admin/import_assessment/")
+
+        assert response.status_code == status.HTTP_200_OK
+        asserts.assertContains(response, "Upload Content")
+
+    def test_assessment_form_has_all_expected_options(self, admin_client):
+        """
+        The upload form has all expected options:
+            - heading
+            - file upload field
+            - csv and Excel file as file type options in a drop down
+            - Yes and No as purge options in a drop down
+            - All current locale and each locale as an option for the languages
+        """
+        response = admin_client.get("/admin/import_assessment/")
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        heading = soup.find("h1").text.strip()
+        assert heading == "Upload Content"
+
+        form = soup.find("form")
+        file_upload = form.find("input", type="file", id="id_file")
+        assert file_upload
+
+        assert find_options(form, "file_type") == ["CSV File", "Excel File"]
+        assert find_options(soup, "purge") == ["No", "Yes"]
+
+
+class TestWhatsAppTemplateImportView:
+    def test_import_whatsapp_template(self, admin_client):
+        """
+        The import page can be accessed at the expected url
+        """
+        response = admin_client.get("/admin/import_whatsapptemplate/")
+
+        assert response.status_code == status.HTTP_200_OK
+        asserts.assertContains(response, "Upload Content")
+
+    def test_whatsapp_template_form_has_all_expected_options(self, admin_client):
+        """
+        The upload form has all expected options:
+            - heading
+            - file upload field
+            - csv and Excel file as file type options in a drop down
+            - Yes and No as purge options in a drop down
+            - All current locale and each locale as an option for the languages
+        """
+        response = admin_client.get("/admin/import_whatsapptemplate/")
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        heading = soup.find("h1").text.strip()
+        assert heading == "Upload Content"
+
+        form = soup.find("form")
+        file_upload = form.find("input", type="file", id="id_file")
+        assert file_upload
+
+        assert find_options(form, "file_type") == ["CSV File", "Excel File"]
+        assert find_options(soup, "purge") == ["No", "Yes"]
+
+
 @pytest.mark.django_db
 class TestPageViewReportView:
     def create_content_page(self, number_of_pages):


### PR DESCRIPTION
## Purpose
To remove the warning for clean builds and less work when we update the wagtail version

## Solution
Fixed the warning: updated class_name to classname

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)

