### PR TITLE
added missing ordered set page slug validation

### DIFF
--- a/home/import_ordered_content_sets.py
+++ b/home/import_ordered_content_sets.py
@@ -162,7 +162,7 @@ class OrderedContentSetImporter:
                 page.time or page.unit or page.before_or_after or page.contact_field
             ):
                 raise ImportException(
-                    f"You are attempting to import an ordered content set with page details, but no page slug.",
+                    "You are attempting to import an ordered content set with page details, but no page slug.",
                     index,
                 )
 

--- a/home/import_ordered_content_sets.py
+++ b/home/import_ordered_content_sets.py
@@ -158,7 +158,7 @@ class OrderedContentSetImporter:
                         f"Content page not found for slug '{page.page_slug}' in locale '{locale}'",
                         index,
                     )
-            if not page.page_slug and (
+            if (not page.page_slug or page.page_slug == "-") and (
                 page.time or page.unit or page.before_or_after or page.contact_field
             ):
                 raise ImportException(

--- a/home/import_ordered_content_sets.py
+++ b/home/import_ordered_content_sets.py
@@ -158,6 +158,13 @@ class OrderedContentSetImporter:
                         f"Content page not found for slug '{page.page_slug}' in locale '{locale}'",
                         index,
                     )
+            if not page.page_slug and (
+                page.time or page.unit or page.before_or_after or page.contact_field
+            ):
+                raise ImportException(
+                    f"You are attempting to import an ordered content set with page details, but no page slug.",
+                    index,
+                )
 
     # FIXME: collect errors across all fields
     def _validate_ordered_set_using_form(

--- a/home/tests/import-export-data/bad_ordered_set.csv
+++ b/home/tests/import-export-data/bad_ordered_set.csv
@@ -1,0 +1,2 @@
+Name,Profile Fields,Page Slugs,Time,Unit,Before Or After,Contact Field,Slug,Locale
+Ordered,,,12,minutes,before,,Slug,en

--- a/home/tests/import-export-data/simple_ordered_set.csv
+++ b/home/tests/import-export-data/simple_ordered_set.csv
@@ -1,0 +1,2 @@
+Name,Profile Fields,Page Slugs,Time,Unit,Before Or After,Contact Field,Slug,Locale
+Ordered,,,,,,,Slug,en

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1452,9 +1452,7 @@ class TestImportExport:
 
         en = Locale.objects.get(language_code="en")
 
-        ordered_set = OrderedContentSet.objects.filter(
-            slug="slug", locale=en
-        ).first()
+        ordered_set = OrderedContentSet.objects.filter(slug="slug", locale=en).first()
 
         assert ordered_set.name == "Ordered"
         pages = unwagtail(ordered_set.pages)

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1442,6 +1442,24 @@ class TestImportExport:
         page = pages[0][1]
         assert page["contentpage"].slug == "first_time_user"
 
+    def test_import_simple_ordered_sets_csv(self, csv_impexp: ImportExport) -> None:
+        """
+        Importing a CSV file with ordered content sets without any contentpage should not break
+        """
+
+        content = csv_impexp.read_bytes("simple_ordered_set.csv")
+        csv_impexp.import_ordered_sets(content)
+
+        en = Locale.objects.get(language_code="en")
+
+        ordered_set = OrderedContentSet.objects.filter(
+            slug="slug", locale=en
+        ).first()
+
+        assert ordered_set.name == "Ordered"
+        pages = unwagtail(ordered_set.pages)
+        assert len(pages) == 0
+
     def test_import_ordered_sets_csv(self, csv_impexp: ImportExport) -> None:
         """
         Importing a CSV file with ordered content sets should not break

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1348,6 +1348,23 @@ class TestImportExport:
             "Content page not found for slug 'first_time_user' in locale 'English'"
         ]
 
+    def test_import_ordered_content_sets_missing_slug(
+        self, csv_impexp: ImportExport
+    ) -> None:
+        """
+        Importing CSV for ordered content sets that has a page slug, but no
+        Unit/Time/EDD/Before_or_After/Contact field, should result in a
+        error message
+        """
+        with pytest.raises(ImportException) as e:
+            content = csv_impexp.read_bytes("bad_ordered_set.csv")
+            csv_impexp.import_ordered_sets(content)
+
+        assert e.value.row_num == 2
+        assert e.value.message == [
+            "You are attempting to import an ordered content set with page details, but no page slug."
+        ]
+
     def test_import_ordered_content_sets_no_locale_error(
         self, csv_impexp: ImportExport
     ) -> None:


### PR DESCRIPTION
## Purpose
When you import an ordered content set with EDD, Unit etc, but without the page slug, then the imported set will not have that data

## Solution
The CMS does not allow imports for ordered sets with page details but no page linked

#### Checklist
- [X] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)

