### PR TITLE
Better warning message for media imports

### DIFF
--- a/home/import_content_pages.py
+++ b/home/import_content_pages.py
@@ -102,7 +102,10 @@ class ContentImporter:
             if row.media_link:
                 if row.media_link is not None or row.media_link != "":
                     self.import_warnings.append(
-                        ImportWarning(f"{row.media_link}", row_num)
+                        ImportWarning(
+                            f"Media import not supported, {row.media_link} not added to {row.slug}",
+                            row_num,
+                        )
                     )
 
     def process_rows(self, rows: list["ContentRow"]) -> None:

--- a/home/tests/test_content_import_export.py
+++ b/home/tests/test_content_import_export.py
@@ -1782,7 +1782,10 @@ class TestImportExport:
         importer = csv_impexp.import_content(content)
 
         assert len(importer.import_warnings) == 2
-        assert importer.import_warnings[0].message == "http://test.com/image.png"
+        assert (
+            importer.import_warnings[0].message
+            == "Media import not supported, http://test.com/image.png not added to main-menu-first-time-user"
+        )
         assert importer.import_warnings[0].row_num == 3
 
 

--- a/home/tests/test_management_import_json_content_turn.py
+++ b/home/tests/test_management_import_json_content_turn.py
@@ -1,6 +1,7 @@
 import json
 from io import StringIO
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 import responses
 from django.core.management import call_command
@@ -57,12 +58,13 @@ class ImportJsonContentTestCase(TestCase):
             status=200,
         )
 
-        sample_json_path = Path("sample.json")
-        with sample_json_path.open("w") as f:
-            json.dump(self.sample_json, f)
-
         out = StringIO()
-        call_command("import_json_content_turn", str(sample_json_path), stdout=out)
+
+        with NamedTemporaryFile() as tempfile:
+            tempfile_path = Path(tempfile.name)
+            with tempfile_path.open("w") as f:
+                json.dump(self.sample_json, f)
+            call_command("import_json_content_turn", tempfile.name, stdout=out)
 
         self.assertIn("Successfully imported Content Pages", out.getvalue())
 
@@ -90,12 +92,14 @@ class ImportJsonContentTestCase(TestCase):
             ]
         }
 
-        sample_json_path = Path("sample.json")
-        with sample_json_path.open("w") as f:
-            json.dump(sample_json, f)
-
         out = StringIO()
-        call_command("import_json_content_turn", str(sample_json_path), stdout=out)
+
+        with NamedTemporaryFile() as tempfile:
+            tempfile_path = Path(tempfile.name)
+            with tempfile_path.open("w") as f:
+                json.dump(sample_json, f)
+            call_command("import_json_content_turn", tempfile.name, stdout=out)
+
         self.assertIn("Successfully imported Content Pages", out.getvalue())
 
         content_page = ContentPage.objects.first()


### PR DESCRIPTION
## Purpose
The current warning message just gives the media URL, it doesn't tell you that it has not imported the media for that page.

## Solution
Expanded error message

#### Checklist
- [x] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)

