### PR TITLE
Resubmit standalone templates when button labels change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated standalone template import / export and pages import / export to link to templates
 ### Removed
 ### Fixed
+- Resubmit templates when button titles change
 ### Security
 -->
 

--- a/home/models.py
+++ b/home/models.py
@@ -1702,7 +1702,6 @@ class WhatsAppTemplate(
         if previous_revision:
             previous_revision = previous_revision.as_object()
             previous_revision_fields = previous_revision.fields
-            print(f"Previous revision fields: {previous_revision_fields}")
             previous_revision_button_titles = [
                 b["value"]["title"] for b in previous_revision.buttons.raw_data
             ]

--- a/home/models.py
+++ b/home/models.py
@@ -861,7 +861,7 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
             self.whatsapp_template_category,
         )
 
-    def submit_whatsapp_template(self, previous_revision):
+    def submit_whatsapp_template(self, previous_revision: Revision) -> str | None:
         """
         Submits a request to the WhatsApp API to create a template for this content
 
@@ -869,9 +869,9 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
         template, and if the template fields are different to the previous revision
         """
         if not settings.WHATSAPP_CREATE_TEMPLATES:
-            return
+            return None
         if not self.is_whatsapp_template:
-            return
+            return None
         # If there are any missing fields in the previous revision, then carry on
         try:
             previous_revision = previous_revision.as_object()
@@ -881,9 +881,9 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
         # If there are any missing fields in this revision, then don't submit template
         try:
             if self.whatsapp_template_fields == previous_revision_fields:
-                return
+                return None
         except (IndexError, AttributeError):
-            return
+            return None
 
         self.whatsapp_template_name = self.create_whatsapp_template_name()
 
@@ -1702,10 +1702,19 @@ class WhatsAppTemplate(
         if previous_revision:
             previous_revision = previous_revision.as_object()
             previous_revision_fields = previous_revision.fields
+            print(f"Previous revision fields: {previous_revision_fields}")
+            previous_revision_button_titles = [
+                b["value"]["title"] for b in previous_revision.buttons.raw_data
+            ]
         else:
             previous_revision_fields = ()
+            previous_revision_button_titles = []
 
-        if self.fields == previous_revision_fields:
+        current_button_titles = [b["value"]["title"] for b in self.buttons.raw_data]
+        if (
+            self.fields == previous_revision_fields
+            and current_button_titles == previous_revision_button_titles
+        ):
             return revision
 
         self.template_name = self.create_whatsapp_template_name()

--- a/home/models.py
+++ b/home/models.py
@@ -1702,18 +1702,9 @@ class WhatsAppTemplate(
         if previous_revision:
             previous_revision = previous_revision.as_object()
             previous_revision_fields = previous_revision.fields
-            previous_revision_button_titles = [
-                b["value"]["title"] for b in previous_revision.buttons.raw_data
-            ]
         else:
             previous_revision_fields = ()
-            previous_revision_button_titles = []
-
-        current_button_titles = [b["value"]["title"] for b in self.buttons.raw_data]
-        if (
-            self.fields == previous_revision_fields
-            and current_button_titles == previous_revision_button_titles
-        ):
+        if self.fields == previous_revision_fields:
             return revision
 
         self.template_name = self.create_whatsapp_template_name()
@@ -1837,7 +1828,7 @@ class WhatsAppTemplate(
         return result
 
     @property
-    def fields(self):
+    def fields(self) -> tuple[Any, Any, Any, Any, list[Any], Any, Any, list[str]]:
         """
         Returns a tuple of fields that can be used to determine template equality
         """
@@ -1849,6 +1840,7 @@ class WhatsAppTemplate(
             sorted(self.quick_reply_buttons),
             self.image,
             self.example_values,
+            [b["value"]["title"] for b in self.buttons.raw_data],
         )
 
     def create_whatsapp_template_name(self) -> str:

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -1029,6 +1029,50 @@ class TestWhatsAppTemplate:
 
     @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
     @responses.activate
+    def test_template_resubmits_when_button_labels_change(self) -> None:
+        url = "http://whatsapp/graph/v14.0/27121231234/message_templates"
+        responses.add(responses.POST, url, json={"id": "123456789"})
+
+        wat = WhatsAppTemplate(
+            name="wa_title",
+            buttons=[
+                ("next_message", {"title": "Test Button"}),
+            ],
+            message="Test WhatsApp Message 1",
+            category="UTILITY",
+            locale=Locale.objects.get(language_code="en"),
+        )
+        wat.save()
+        wat.save_revision().publish()
+
+        wat.buttons = [
+            ("next_message", {"title": "Test Button 2"}),
+        ]
+        wat.save_revision().publish()
+
+        wat_from_db = WhatsAppTemplate.objects.last()
+
+        assert wat_from_db.submission_status == "SUBMITTED"
+        assert "Success! Template ID " in wat_from_db.submission_result
+        assert len(responses.calls) == 2
+        request = responses.calls[1].request
+        assert json.loads(request.body) == {
+            "category": "UTILITY",
+            "components": [
+                {"text": "Test WhatsApp Message 1", "type": "BODY"},
+                {
+                    "type": "BUTTONS",
+                    "buttons": [
+                        {"text": "Test Button 2", "type": "QUICK_REPLY"},
+                    ],
+                },
+            ],
+            "language": "en_US",
+            "name": f"wa_title_{wat.get_latest_revision().id}",
+        }
+
+    @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
+    @responses.activate
     def test_template_create_with_example_values(self) -> None:
         url = "http://whatsapp/graph/v14.0/27121231234/message_templates"
         responses.add(responses.POST, url, json={"id": "123456789"})

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -1045,6 +1045,8 @@ class TestWhatsAppTemplate:
         wat.save()
         wat.save_revision().publish()
 
+        assert len(responses.calls) == 1
+
         wat.buttons = [
             ("next_message", {"title": "Test Button 2"}),
         ]


### PR DESCRIPTION
## Purpose
Currently we don't resubmit standalone templates when the button titles change.

## Solution
This fixes the problem so that the templates resubmit.

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
