### PR TITLE
Fix WA template export reimport

### DIFF
--- a/home/import_whatsapp_templates.py
+++ b/home/import_whatsapp_templates.py
@@ -110,7 +110,20 @@ class WhatsAppTemplateImporter:
         self, row: "ContentRow", locale: Locale
     ) -> WhatsAppTemplate:
         try:
-            return WhatsAppTemplate.objects.get(name=row.name, locale=locale)
+            template = WhatsAppTemplate.objects.get(name=row.name, locale=locale)
+            template.category = row.category
+            template.message = row.message
+            template.example_values = [
+                ("example_values", v) for v in row.example_values
+            ]
+            template.submission_status = (
+                row.submission_status
+                if row.submission_status
+                else WhatsAppTemplate.SubmissionStatus.NOT_SUBMITTED_YET
+            )
+            template.submission_result = row.submission_result
+            template.submission_name = row.submission_name
+            return template
         except WhatsAppTemplate.DoesNotExist:
             return WhatsAppTemplate(
                 name=row.name,

--- a/home/import_whatsapp_templates.py
+++ b/home/import_whatsapp_templates.py
@@ -93,20 +93,7 @@ class WhatsAppTemplateImporter:
                 f"Validation error: whatsapp_template_category - Select a valid choice. {row.category} is not one of the available choices."
             )
 
-        template = WhatsAppTemplate(
-            name=row.name,
-            category=row.category,
-            locale=locale,
-            message=row.message,
-            example_values=[("example_values", v) for v in row.example_values],
-            submission_status=(
-                row.submission_status
-                if row.submission_status
-                else WhatsAppTemplate.SubmissionStatus.NOT_SUBMITTED_YET
-            ),
-            submission_result=row.submission_result,
-            submission_name=row.submission_name,
-        )
+        template = self._get_or_init_whatsapp_template(row, locale)
         template.full_clean()
         template.save()
 
@@ -118,6 +105,27 @@ class WhatsAppTemplateImporter:
         template.full_clean()
         template.save()
         return
+
+    def _get_or_init_whatsapp_template(
+        self, row: "ContentRow", locale: Locale
+    ) -> WhatsAppTemplate:
+        try:
+            return WhatsAppTemplate.objects.get(name=row.name, locale=locale)
+        except WhatsAppTemplate.DoesNotExist:
+            return WhatsAppTemplate(
+                name=row.name,
+                category=row.category,
+                locale=locale,
+                message=row.message,
+                example_values=[("example_values", v) for v in row.example_values],
+                submission_status=(
+                    row.submission_status
+                    if row.submission_status
+                    else WhatsAppTemplate.SubmissionStatus.NOT_SUBMITTED_YET
+                ),
+                submission_result=row.submission_result,
+                submission_name=row.submission_name,
+            )
 
     def parse_file(self) -> list["ContentRow"]:
         if self.file_type == "XLSX":

--- a/home/tests/test_whatsapp_template_import_export.py
+++ b/home/tests/test_whatsapp_template_import_export.py
@@ -204,11 +204,11 @@ class ImportExport:
         self.import_whatsapp_template(content, **kw)
         return content
 
-    def export_reimport(self) -> None:
+    def export_reimport(self, **kw: Any) -> None:
         """
         Export all content, then immediately reimport it.
         """
-        self.import_whatsapp_template(self.export_whatsapp_template())
+        self.import_whatsapp_template(self.export_whatsapp_template(), **kw)
 
     def csvs2dicts(self, src_bytes: bytes, dst_bytes: bytes) -> ExpDictsPair:
         src = csv2dicts(src_bytes)
@@ -329,7 +329,7 @@ class TestImportExportRoundtrip:
         )
 
         orig = impexp.get_whatsapp_template_json()
-        impexp.export_reimport()
+        impexp.export_reimport(purge=False)
         imported = impexp.get_whatsapp_template_json()
         # remove the revision and unpublished changes keys
         for item in orig:


### PR DESCRIPTION
## Purpose
Exporting and importing a WA template leads to an error on the import screen.

## Solution
The test was only checking if purge was set to true, which would clear the db and reimport. If purge is false though then the reimport fails due to there already being an entry. We now check if there is an entry and return it with the new data.

#### Checklist
- [ ] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
