### PR TITLE
Slug not populated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ GitHub.sublime-settings
 .idea/
 
 .DS_Store
+
+# asdf
+.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - Resubmit templates when button titles change
+- Fix slug not populated in wa template export
 ### Security
 -->
 

--- a/home/import_assessments.py
+++ b/home/import_assessments.py
@@ -281,7 +281,6 @@ class ShadowAssessment:
             e.row_num = self.row_num
             e.slug = assessment.slug
             e.locale = assessment.locale
-            print(f"{e.row_num}: {e.message}")
             raise e
 
     def add_field_values_to_assessment(self, assessment: Assessment) -> None:

--- a/home/import_whatsapp_templates.py
+++ b/home/import_whatsapp_templates.py
@@ -97,10 +97,13 @@ class WhatsAppTemplateImporter:
         template.full_clean()
         template.save()
 
+        print(f"Row Buttons: {row.buttons}")
+        print(f"Template Buttons before creating new ones: {template.buttons}")
         buttons = self._create_interactive_items(
             row.buttons, template.name, locale, "button"
         )
         template.buttons = buttons
+        print(f"Buttons after assigning to template: {buttons}")
 
         template.full_clean()
         template.save()

--- a/home/import_whatsapp_templates.py
+++ b/home/import_whatsapp_templates.py
@@ -97,13 +97,10 @@ class WhatsAppTemplateImporter:
         template.full_clean()
         template.save()
 
-        print(f"Row Buttons: {row.buttons}")
-        print(f"Template Buttons before creating new ones: {template.buttons}")
         buttons = self._create_interactive_items(
             row.buttons, template.name, locale, "button"
         )
         template.buttons = buttons
-        print(f"Buttons after assigning to template: {buttons}")
 
         template.full_clean()
         template.save()

--- a/home/tests/test_whatsapp_template_import_export.py
+++ b/home/tests/test_whatsapp_template_import_export.py
@@ -12,7 +12,7 @@ import pytest
 from django.core import serializers  # type: ignore
 from openpyxl import load_workbook
 from pytest_django.fixtures import SettingsWrapper
-from wagtail.blocks.stream_block import StreamValue
+from wagtail.blocks.stream_block import StreamValue  # type: ignore
 from wagtail.models import Locale  # type: ignore
 from wagtail.snippets.models import register_snippet  # type: ignore
 

--- a/home/tests/test_whatsapp_template_import_export.py
+++ b/home/tests/test_whatsapp_template_import_export.py
@@ -19,6 +19,7 @@ from wagtail.snippets.models import register_snippet  # type: ignore
 from home.assessment_import_export import import_assessment
 from home.import_helpers import ImportException
 from home.models import (
+    Assessment,
     HomePage,
     WhatsAppTemplate,
 )
@@ -403,6 +404,10 @@ class TestImportExportRoundtrip:
         Exporting then reimporting leaves the database in the same state we started with
         """
         csv_impexp.import_assessment_file("assessment_simple.csv")
+        assessment_id = Assessment.objects.get(
+            title="Health Assessment Simple",
+            locale=Locale.objects.get(language_code="en"),
+        ).id
         example_values_field = WhatsAppTemplate._meta.get_field("example_values")
         example_values = StreamValue(
             example_values_field.stream_block,
@@ -416,7 +421,10 @@ class TestImportExportRoundtrip:
         buttons = StreamValue(
             buttons_field.stream_block,
             [
-                {"type": "go_to_form", "value": {"title": "Simple form", "form": 1}},
+                {
+                    "type": "go_to_form",
+                    "value": {"title": "Simple form", "form": assessment_id},
+                },
             ],
             is_lazy=True,
         )


### PR DESCRIPTION
# Note: This PR needs to wait for [448](https://github.com/praekeltfoundation/contentrepo/pull/448)

## Purpose
In the downloaded content sheet for Templates with buttons the slug field is not populated. This PR fixes that.

## Solution
We populate the slug.

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
