### PR TITLE
Don't show Send to Meta on the add page for WA Templates

### DIFF
--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -163,6 +163,9 @@ class SubmitToMetaMenuItem(ActionMenuItem):
         instance = context["instance"]
         return reverse("submit_to_meta", args=[instance.pk])
 
+    def is_shown(self, context: Any) -> bool:
+        return context["view"] == "edit"
+
 
 @hooks.register("register_snippet_action_menu_item")
 def register_submit_to_meta_menu_item(model: Any) -> Any:


### PR DESCRIPTION
## Purpose
The Send to Meta button is trying to show on the Add Whatsapp Template page, which crashes the page.

## Solution
Don't show the button on the Add page.

#### Checklist
- [ ] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
