### PR TITLE
Fix export issue for contentpages because of Standalone Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Resubmit templates when button titles change
 - Fix slug not populated in wa template export
+- Fix export issue for contentpages because of Standalone Templates
 ### Security
 -->
 


### PR DESCRIPTION
## Purpose
Content page exports are failing because of standalone templates.

## Solution
We check the type of the Whatsapp message in the content page model, and correctly extract the data from the WhatsApp Templates.

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
