### PR TITLE
Use the page name instead of what could be an empty field

### DIFF
--- a/contentrepo/settings/base.py
+++ b/contentrepo/settings/base.py
@@ -268,5 +268,5 @@ EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT", None)
 
 # Flag for turning on Standalone Whatsapp Templates, still in development
 ENABLE_STANDALONE_WHATSAPP_TEMPLATES = env.bool(
-    "ENABLE_STANDALONE_WHATSAPP_TEMPLATES", True
+    "ENABLE_STANDALONE_WHATSAPP_TEMPLATES", False
 )

--- a/contentrepo/settings/base.py
+++ b/contentrepo/settings/base.py
@@ -268,5 +268,5 @@ EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT", None)
 
 # Flag for turning on Standalone Whatsapp Templates, still in development
 ENABLE_STANDALONE_WHATSAPP_TEMPLATES = env.bool(
-    "ENABLE_STANDALONE_WHATSAPP_TEMPLATES", False
+    "ENABLE_STANDALONE_WHATSAPP_TEMPLATES", True
 )

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -1,5 +1,45 @@
 from django.db import migrations
 from typing import Any
+from django.db.models import Count
+
+
+def rename_duplicate_whatsapp_titles(ContentPage: Any) -> None:
+    duplicate_whatsapp_titles = (
+        ContentPage.objects.values("whatsapp_title")
+        .annotate(count=Count("whatsapp_title"))
+        .filter(count__gt=1)
+        .values_list("whatsapp_title", flat=True)
+    )
+    for whatsapp_title in duplicate_whatsapp_titles:
+        pages = ContentPage.objects.filter(whatsapp_title=whatsapp_title)
+        while pages.count() > 1:
+            page = pages.first()
+            suffix = 1
+            candidate_whatsapp_title = whatsapp_title
+            while ContentPage.objects.filter(
+                whatsapp_title=candidate_whatsapp_title
+            ).exists():
+                suffix += 1
+                candidate_whatsapp_title = f"{whatsapp_title}-{suffix}"
+            page.whatsapp_title = candidate_whatsapp_title
+            page.save(update_fields=["whatsapp_title"])
+
+
+def rename_matching_whatsapp_names(ContentPage: Any, WhatsAppTemplate: Any) -> None:
+    templates = WhatsAppTemplate.objects.all()
+    for template in templates:
+        pages = ContentPage.objects.filter(whatsapp_title=template.name)
+        while pages.count() > 1:
+            page = pages.first()
+            suffix = 1
+            candidate_whatsapp_title = template.name
+            while ContentPage.objects.filter(
+                whatsapp_title=candidate_whatsapp_title
+            ).exists():
+                suffix += 1
+                candidate_whatsapp_title = f"{template.name}-{suffix}"
+            page.whatsapp_title = candidate_whatsapp_title
+            page.save(update_fields=["whatsapp_title"])
 
 
 def migrate_content_page_templates_to_standalone_templates(
@@ -32,7 +72,7 @@ def migrate_content_page_templates_to_standalone_templates(
                 print("No image")
             example_values = list(whatsapp_value.get("example_values", []))
             whatsapp_template = WhatsAppTemplate.objects.create(
-                name=f'{content_page.whatsapp_title.lower().replace(" ", "_")}_{content_page.get_latest_revision().pk}',
+                name=content_page.whatsapp_title.lower().replace(" ", "_"),
                 locale=content_page.locale,
                 message=whatsapp_value.get("message", ""),
                 example_values=[
@@ -56,6 +96,8 @@ def run_migration(apps: Any, schema_editor: Any) -> None:
     ContentPage = apps.get_model("home", "ContentPage")
     WhatsAppTemplate = apps.get_model("home", "WhatsAppTemplate")
     Image = apps.get_model("wagtailimages", "Image")
+    rename_duplicate_whatsapp_titles(ContentPage)
+    rename_matching_whatsapp_names(ContentPage, WhatsAppTemplate)
     migrate_content_page_templates_to_standalone_templates(
         ContentPage, WhatsAppTemplate, Image
     )

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -13,7 +13,10 @@ def migrate_content_page_templates_to_standalone_templates(
         print(f"Content Page slug: {content_page.slug}")
         print(f"Content page title: {content_page.whatsapp_title}")
         print(f"Whatsapp Value type: {type(whatsapp_value)}, value: {whatsapp_value}")
-        if whatsapp_value._meta.verbose_name != "WhatsApp Template":
+        if (
+            not hasattr(whatsapp_value, "_meta")
+            or whatsapp_value._meta.verbose_name != "WhatsApp Template"
+        ):
             image = whatsapp_value.get("image", None)
             if image:
                 print(f"Image type: {type(image)}")

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -12,40 +12,40 @@ def migrate_content_page_templates_to_standalone_templates(
         whatsapp_value = whatsapp_block.value
         print(f"Content Page slug: {content_page.slug}")
         print(f"Content page title: {content_page.whatsapp_title}")
-        if isinstance(whatsapp_value, WhatsAppTemplate):
-            continue
-        image = whatsapp_value.get("image", None)
-        if image:
-            print(f"Image type: {type(image)}")
-            if isinstance(image, int):
-                image = Image.objects.get(id=image)
-            elif hasattr(image, "id"):
-                image = Image.objects.get(id=image.id)
-            elif isinstance(image, dict) and "id" in image:
-                image = Image.objects.get(id=image["id"])
+        if not isinstance(whatsapp_value, WhatsAppTemplate):
+            image = whatsapp_value.get("image", None)
+            if image:
+                print(f"Image type: {type(image)}")
+                if isinstance(image, int):
+                    image = Image.objects.get(id=image)
+                elif hasattr(image, "id"):
+                    image = Image.objects.get(id=image.id)
+                elif isinstance(image, dict) and "id" in image:
+                    image = Image.objects.get(id=image["id"])
+                else:
+                    image = None
             else:
-                image = None
-        else:
-            print("No image")
-        example_values = list(whatsapp_value.get("example_values", []))
-        whatsapp_template = WhatsAppTemplate.objects.create(
-            name=content_page.whatsapp_title.lower().replace(" ", "_"),
-            locale=content_page.locale,
-            message=whatsapp_value.get("message", ""),
-            example_values=[
-                ("example_values", example_value) for example_value in example_values
-            ],
-            category=content_page.whatsapp_template_category,
-            buttons=whatsapp_value.get("buttons", []),
-            image=image,
-            submission_status="NOT_SUBMITTED_YET",
-            submission_result="",
-        )
-        content_page.whatsapp_body = []
-        content_page.whatsapp_body.append(("Whatsapp_Template", whatsapp_template))
-        content_page.is_whatsapp_template = False
-        content_page.save()
-        print("Content Page Saved")
+                print("No image")
+            example_values = list(whatsapp_value.get("example_values", []))
+            whatsapp_template = WhatsAppTemplate.objects.create(
+                name=content_page.whatsapp_title.lower().replace(" ", "_"),
+                locale=content_page.locale,
+                message=whatsapp_value.get("message", ""),
+                example_values=[
+                    ("example_values", example_value)
+                    for example_value in example_values
+                ],
+                category=content_page.whatsapp_template_category,
+                buttons=whatsapp_value.get("buttons", []),
+                image=image,
+                submission_status="NOT_SUBMITTED_YET",
+                submission_result="",
+            )
+            content_page.whatsapp_body = []
+            content_page.whatsapp_body.append(("Whatsapp_Template", whatsapp_template))
+            content_page.is_whatsapp_template = False
+            content_page.save()
+            print("Content Page Saved")
 
 
 def run_migration(apps: Any, schema_editor: Any) -> None:

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -25,11 +25,14 @@ def migrate_content_page_templates_to_standalone_templates(
                 image = None
         else:
             print("No image")
+        example_values = list(whatsapp_value.get("example_values", []))
         whatsapp_template = WhatsAppTemplate.objects.create(
             name=content_page.whatsapp_title.lower().replace(" ", "_"),
             locale=content_page.locale,
             message=whatsapp_value.get("message", ""),
-            example_values=list(whatsapp_value.get("example_values", [])),
+            example_values=[
+                ("example_values", example_value) for example_value in example_values
+            ],
             category=content_page.whatsapp_template_category,
             buttons=whatsapp_value.get("buttons", []),
             image=image,

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -1,10 +1,9 @@
 from django.db import migrations
 from typing import Any
-from wagtail.images.models import Image
 
 
 def migrate_content_page_templates_to_standalone_templates(
-    ContentPage: Any, WhatsAppTemplate: Any
+    ContentPage: Any, WhatsAppTemplate: Any, Image: Any
 ) -> None:
     content_pages = ContentPage.objects.filter(is_whatsapp_template=True)
 
@@ -16,7 +15,14 @@ def migrate_content_page_templates_to_standalone_templates(
         image = whatsapp_value.get("image", None)
         if image:
             print(f"Image type: {type(image)}")
-            image = Image.objects.get(id=image.id)
+            if isinstance(image, int):
+                image = Image.objects.get(id=image)
+            elif hasattr(image, "id"):
+                image = Image.objects.get(id=image.id)
+            elif isinstance(image, dict) and "id" in image:
+                image = Image.objects.get(id=image["id"])
+            else:
+                image = None
         else:
             print("No image")
         whatsapp_template = WhatsAppTemplate.objects.create(
@@ -40,8 +46,9 @@ def migrate_content_page_templates_to_standalone_templates(
 def run_migration(apps: Any, schema_editor: Any) -> None:
     ContentPage = apps.get_model("home", "ContentPage")
     WhatsAppTemplate = apps.get_model("home", "WhatsAppTemplate")
+    Image = apps.get_model("wagtailimages", "Image")
     migrate_content_page_templates_to_standalone_templates(
-        ContentPage, WhatsAppTemplate
+        ContentPage, WhatsAppTemplate, Image
     )
 
 

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -11,7 +11,7 @@ def migrate_content_page_templates_to_standalone_templates(
         whatsapp_block = content_page.whatsapp_body[0]
         whatsapp_value = whatsapp_block.value
         whatsapp_template = WhatsAppTemplate.objects.create(
-            name=content_page.whatsapp_template_name,
+            name=content_page.whatsapp_title.lower().replace(" ", "_"),
             locale=content_page.locale,
             message=whatsapp_value.get("message", ""),
             example_values=whatsapp_value.get("example_values", []),

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -29,7 +29,7 @@ def migrate_content_page_templates_to_standalone_templates(
             name=content_page.whatsapp_title.lower().replace(" ", "_"),
             locale=content_page.locale,
             message=whatsapp_value.get("message", ""),
-            example_values=whatsapp_value.get("example_values", []),
+            example_values=list(whatsapp_value.get("example_values", [])),
             category=content_page.whatsapp_template_category,
             buttons=whatsapp_value.get("buttons", []),
             image=image,

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -32,7 +32,7 @@ def migrate_content_page_templates_to_standalone_templates(
                 print("No image")
             example_values = list(whatsapp_value.get("example_values", []))
             whatsapp_template = WhatsAppTemplate.objects.create(
-                name=content_page.whatsapp_title.lower().replace(" ", "_"),
+                name=f'{content_page.whatsapp_title.lower().replace(" ", "_")}_{content_page.get_latest_revision().pk}',
                 locale=content_page.locale,
                 message=whatsapp_value.get("message", ""),
                 example_values=[

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -82,8 +82,9 @@ def migrate_content_page_templates_to_standalone_templates(
             submission_status="NOT_SUBMITTED_YET",
             submission_result="",
         )
-        content_page.whatsapp_body = []
-        content_page.whatsapp_body.append(("Whatsapp_Template", whatsapp_template))
+        wb = content_page.whatsapp_body
+        wb[0] = ("Whatsapp_Template", whatsapp_template)
+        content_page.whatsapp_body = wb
         content_page.is_whatsapp_template = False
         content_page.save()
 

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -1,5 +1,6 @@
 from django.db import migrations
 from typing import Any
+from wagtail.images.models import Image
 
 
 def migrate_content_page_templates_to_standalone_templates(
@@ -10,10 +11,12 @@ def migrate_content_page_templates_to_standalone_templates(
     for content_page in content_pages:
         whatsapp_block = content_page.whatsapp_body[0]
         whatsapp_value = whatsapp_block.value
+        print(f"Content Page slug: {content_page.slug}")
         print(f"Content page title: {content_page.whatsapp_title}")
         image = whatsapp_value.get("image", None)
         if image:
             print(f"Image type: {type(image)}")
+            image = Image.objects.get(id=image.id)
         else:
             print("No image")
         whatsapp_template = WhatsAppTemplate.objects.create(
@@ -23,7 +26,7 @@ def migrate_content_page_templates_to_standalone_templates(
             example_values=whatsapp_value.get("example_values", []),
             category=content_page.whatsapp_template_category,
             buttons=whatsapp_value.get("buttons", []),
-            image=whatsapp_value.get("image", None),
+            image=image,
             submission_status="NOT_SUBMITTED_YET",
             submission_result="",
         )

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -13,7 +13,7 @@ def migrate_content_page_templates_to_standalone_templates(
         print(f"Content Page slug: {content_page.slug}")
         print(f"Content page title: {content_page.whatsapp_title}")
         print(f"Whatsapp Value type: {type(whatsapp_value)}, value: {whatsapp_value}")
-        if not isinstance(whatsapp_value, WhatsAppTemplate):
+        if whatsapp_value._meta.verbose_name != "WhatsApp Template":
             image = whatsapp_value.get("image", None)
             if image:
                 print(f"Image type: {type(image)}")

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -10,6 +10,12 @@ def migrate_content_page_templates_to_standalone_templates(
     for content_page in content_pages:
         whatsapp_block = content_page.whatsapp_body[0]
         whatsapp_value = whatsapp_block.value
+        print(f"Content page title: {content_page.whatsapp_title}")
+        image = whatsapp_value.get("image", None)
+        if image:
+            print(f"Image type: {type(image)}")
+        else:
+            print("No image")
         whatsapp_template = WhatsAppTemplate.objects.create(
             name=content_page.whatsapp_title.lower().replace(" ", "_"),
             locale=content_page.locale,
@@ -25,6 +31,7 @@ def migrate_content_page_templates_to_standalone_templates(
         content_page.whatsapp_body.append(("Whatsapp_Template", whatsapp_template))
         content_page.is_whatsapp_template = False
         content_page.save()
+        print("Content Page Saved")
 
 
 def run_migration(apps: Any, schema_editor: Any) -> None:

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -12,6 +12,7 @@ def migrate_content_page_templates_to_standalone_templates(
         whatsapp_value = whatsapp_block.value
         print(f"Content Page slug: {content_page.slug}")
         print(f"Content page title: {content_page.whatsapp_title}")
+        print(f"Whatsapp Value type: {type(whatsapp_value)}, value: {whatsapp_value}")
         if not isinstance(whatsapp_value, WhatsAppTemplate):
             image = whatsapp_value.get("image", None)
             if image:

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -12,6 +12,8 @@ def migrate_content_page_templates_to_standalone_templates(
         whatsapp_value = whatsapp_block.value
         print(f"Content Page slug: {content_page.slug}")
         print(f"Content page title: {content_page.whatsapp_title}")
+        if isinstance(whatsapp_value, WhatsAppTemplate):
+            continue
         image = whatsapp_value.get("image", None)
         if image:
             print(f"Image type: {type(image)}")

--- a/home/tests/test_migrations.py
+++ b/home/tests/test_migrations.py
@@ -276,7 +276,13 @@ class MigrationTests(TestCase):
                     "value": {
                         "message": "Sample body",
                     },
-                }
+                },
+                {
+                    "type": "Whatsapp_Message",
+                    "value": {
+                        "message": "Sample body 2",
+                    },
+                },
             ],
         )
         root_page.add_child(instance=content_page)
@@ -314,8 +320,12 @@ class MigrationTests(TestCase):
         self.assertEqual(whatsapp_template.submission_result, "")
 
         self.assertFalse(content_page.is_whatsapp_template)
-        self.assertEqual(len(content_page.whatsapp_body), 1)
+
+        self.assertEqual(len(content_page.whatsapp_body), 2)
         self.assertEqual(content_page.whatsapp_body[0].value, whatsapp_template)
+        self.assertEqual(
+            content_page.whatsapp_body[1].value["message"], "Sample body 2"
+        )
 
         whatsapp_template.delete()
         content_page.delete()


### PR DESCRIPTION
## Purpose
We discovered that the whatsapp_template_name field can be empty for unsubmitted templates, and that's not what we want anyway.

## Solution
Use the code from the prefix.

#### Checklist
- [ ] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
