### PR TITLE
Add the locale into the template submission name

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -1589,7 +1589,7 @@ class WhatsAppTemplate(
 
     @property
     def prefix(self) -> str:
-        return self.name.lower().replace(" ", "_")
+        return f"{self.name.lower().replace(' ', '_')}_{self.locale.language_code}"
 
     @property
     def revisions(self) -> GenericRelation:

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -646,7 +646,7 @@ class WhatsAppTemplateTests(TestCase):
                 },
             ],
             "language": "en_US",
-            "name": f"valid-named-variables_{wat.get_latest_revision().id}",
+            "name": f"valid-named-variables_en_{wat.get_latest_revision().id}",
         }
 
     @override_settings(WHATSAPP_ALLOW_NAMED_VARIABLES=True)
@@ -782,7 +782,7 @@ class WhatsAppTemplateTests(TestCase):
             "category": "UTILITY",
             "components": [{"text": "Test WhatsApp Message 1", "type": "BODY"}],
             "language": "en_US",
-            "name": f"wa_title_{wat.get_latest_revision().id}",
+            "name": f"wa_title_en_{wat.get_latest_revision().id}",
         }
 
     @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
@@ -822,7 +822,7 @@ class WhatsAppTemplateTests(TestCase):
                 },
             ],
             "language": "en_US",
-            "name": f"wa_title_{wat.get_latest_revision().id}",
+            "name": f"wa_title_en_{wat.get_latest_revision().id}",
         }
 
     @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
@@ -872,7 +872,7 @@ class WhatsAppTemplateTests(TestCase):
                 },
             ],
             "language": "en_US",
-            "name": f"wa_title_{wat.get_latest_revision().id}",
+            "name": f"wa_title_en_{wat.get_latest_revision().id}",
         }
 
     @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
@@ -908,7 +908,7 @@ class WhatsAppTemplateTests(TestCase):
                 },
             ],
             "language": "en_US",
-            "name": f"wa_title_{wat.get_latest_revision().id}",
+            "name": f"wa_title_en_{wat.get_latest_revision().id}",
         }
 
     @override_settings(WHATSAPP_CREATE_TEMPLATES=True)

--- a/home/tests/test_whatsapp.py
+++ b/home/tests/test_whatsapp.py
@@ -419,7 +419,7 @@ def test_submit_revision(monkeypatch: pytest.MonkeyPatch) -> None:
 
     rev3 = wat.revisions.order_by("-created_at").first()
     rev3_obj = rev3.as_object()
-    assert rev3_obj.submission_name == f"valid-named-variables_{pk}"
+    assert rev3_obj.submission_name == f"valid-named-variables_en_{pk}"
     assert rev3_obj.submission_status == DummySubmissionStatus.SUBMITTED
     assert rev3_obj.submission_result.startswith("Success! Template ID = ")
 

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -222,6 +222,7 @@ class ContentPageAdmin(ModelAdmin):
         "tag",
         "related_pages",
         "parental",
+        "has_whatsapp_template",
     )
     list_filter = ("locale",)
 


### PR DESCRIPTION
Add the locale into the template submission name to prevent duplicate submissions across locales

## Purpose
When submitting to meta it's possible to have duplicate submission names across locales.

## Solution
Include the locale in the submission name.

#### Checklist
- [ ] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
