### PR TITLE
Fix template submission name

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from collections.abc import Callable
 from typing import Any, Optional, TypeVar
 
@@ -1594,7 +1595,8 @@ class WhatsAppTemplate(
 
     @property
     def prefix(self) -> str:
-        return self.slug
+        # lowercase the slug and replace all special characters with underscores because Meta only allows lowercase letters and underscores
+        return re.sub(r"[^a-z0-9]+", "_", self.slug.lower())
 
     @property
     def revisions(self) -> GenericRelation:

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -646,7 +646,7 @@ class WhatsAppTemplateTests(TestCase):
                 },
             ],
             "language": "en_US",
-            "name": f"valid-named-variables_{wat.get_latest_revision().id}",
+            "name": f"valid_named_variables_{wat.get_latest_revision().id}",
         }
 
     @override_settings(WHATSAPP_ALLOW_NAMED_VARIABLES=True)
@@ -782,7 +782,7 @@ class WhatsAppTemplateTests(TestCase):
             "category": "UTILITY",
             "components": [{"text": "Test WhatsApp Message 1", "type": "BODY"}],
             "language": "en_US",
-            "name": f"wa-title_{wat.get_latest_revision().id}",
+            "name": f"wa_title_{wat.get_latest_revision().id}",
         }
 
     @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
@@ -822,7 +822,7 @@ class WhatsAppTemplateTests(TestCase):
                 },
             ],
             "language": "en_US",
-            "name": f"wa-title_{wat.get_latest_revision().id}",
+            "name": f"wa_title_{wat.get_latest_revision().id}",
         }
 
     @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
@@ -872,7 +872,7 @@ class WhatsAppTemplateTests(TestCase):
                 },
             ],
             "language": "en_US",
-            "name": f"wa-title_{wat.get_latest_revision().id}",
+            "name": f"wa_title_{wat.get_latest_revision().id}",
         }
 
     @override_settings(WHATSAPP_CREATE_TEMPLATES=True)
@@ -908,7 +908,7 @@ class WhatsAppTemplateTests(TestCase):
                 },
             ],
             "language": "en_US",
-            "name": f"wa-title_{wat.get_latest_revision().id}",
+            "name": f"wa_title_{wat.get_latest_revision().id}",
         }
 
     @override_settings(WHATSAPP_CREATE_TEMPLATES=True)

--- a/home/tests/test_whatsapp.py
+++ b/home/tests/test_whatsapp.py
@@ -419,7 +419,7 @@ def test_submit_revision(monkeypatch: pytest.MonkeyPatch) -> None:
 
     rev3 = wat.revisions.order_by("-created_at").first()
     rev3_obj = rev3.as_object()
-    assert rev3_obj.submission_name == f"valid-named-variables_{pk}"
+    assert rev3_obj.submission_name == f"valid_named_variables_{pk}"
     assert rev3_obj.submission_status == DummySubmissionStatus.SUBMITTED
     assert rev3_obj.submission_result.startswith("Success! Template ID = ")
 


### PR DESCRIPTION
## Purpose
Meta does not allow template names with anything other than lowercase letters and underscores in them. 

## Solution
This takes the slug that we use for that name, lowercases it, and replaces any special characters with underscores.

#### Checklist
- [x] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
