### PR TITLE
Add submission status and submission name to the migration

### DIFF
--- a/contentrepo/settings/base.py
+++ b/contentrepo/settings/base.py
@@ -268,5 +268,5 @@ EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT", None)
 
 # Flag for turning on Standalone Whatsapp Templates, still in development
 ENABLE_STANDALONE_WHATSAPP_TEMPLATES = env.bool(
-    "ENABLE_STANDALONE_WHATSAPP_TEMPLATES", False
+    "ENABLE_STANDALONE_WHATSAPP_TEMPLATES", True
 )

--- a/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
+++ b/home/migrations/0099_migrate_content_page_templates_to_standalone_templates.py
@@ -49,8 +49,13 @@ def migrate_content_page_templates_to_standalone_templates(
             category=content_page.whatsapp_template_category,
             buttons=whatsapp_value.get("buttons", []),
             image=image,
-            submission_status="NOT_SUBMITTED_YET",
+            submission_status=(
+                "SUBMITTED"
+                if content_page.is_whatsapp_template
+                else "NOT_SUBMITTED_YET"
+            ),
             submission_result="",
+            submission_name=content_page.whatsapp_template_name,
         )
         wb = content_page.whatsapp_body
         wb[0] = ("Whatsapp_Template", whatsapp_template)


### PR DESCRIPTION
## Purpose
After migrating, we don't want to resubmit, which means we need to indicate that it has been submitted and what the submission name is, so that the name gets surfaced in the API.

## Solution
I added in the fields. 

I tested locally by rolling back to v1.5.0, importing a page that had a template_name, and then ran the migration to see that it worked.

#### Checklist
- [ ] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
