### PR TITLE
Refactor param filtering 4

### DIFF
--- a/home/api.py
+++ b/home/api.py
@@ -25,6 +25,7 @@ from .models import (  # isort:skip
     ContentPageTag,
     TriggeredContent,
 )
+from typing import Any
 
 pp.pprint("Here")
 json.dumps({})
@@ -92,7 +93,7 @@ class ContentPagesViewSet(PagesAPIViewSet):
 
     #     return super().listing_view(request)
 
-    def get_queryset(self):
+    def get_queryset(self) -> Any:
         qa = self.request.query_params.get("qa", "").lower() == "true"
 
         if qa:
@@ -102,7 +103,7 @@ class ContentPagesViewSet(PagesAPIViewSet):
             for cp in queryset:
                 print("")
                 print(
-                    f"Found content page with title = {cp.title}, latest_revision_id = {cp.latest_revision_id}, live_rev_id = {cp.live_revision_id}, message={cp.whatsapp_body[0].value["message"]} "
+                    f"Found content page with title = {cp.title}, latest_revision_id = {cp.latest_revision_id}, live_rev_id = {cp.live_revision_id}, message={cp.whatsapp_body[0].value['message']} "
                 )
                 print(cp.whatsapp_body[0].value["message"])
                 # pp.pprint(vars(cp))
@@ -121,7 +122,10 @@ class ContentPagesViewSet(PagesAPIViewSet):
                     latest_revision = latest_revision.as_object()
                     # set the assessment's details to that of the latest revision
                     # cp = latest_revision
+                    print(f"WA BODY LENGTH: {len(cp.whatsapp_body)}")
+                    print(f"MESSAGE BEFORE: {cp.whatsapp_body[0].value['message']}")
                     cp.whatsapp_body[0].value["message"] = "wtf"
+                    print(f"MESSAGE AFTER: {cp.whatsapp_body[0].value['message']}")
                     # content_page.slug = latest_revision.slug
                     # content_page.version = latest_revision.version
                     # content_page.locale = latest_revision.locale
@@ -141,7 +145,13 @@ class ContentPagesViewSet(PagesAPIViewSet):
                 # print(json.dumps(item, indent=2))
                 pp.pprint(vars(item), indent=2)
 
-        queryset = queryset.prefetch_related("locale")
+        for cp in queryset:
+            print(f" CP BEFORE PREFETCH: {cp.whatsapp_body[0].value['message']}")
+
+        # queryset = queryset.prefetch_related("locale")
+
+        for cp in queryset:
+            print(f" CP AFTER PREFETCH: {cp.whatsapp_body[0].value['message']}")
 
         if "web" in self.request.query_params:
             queryset = queryset.filter(enable_web=True)

--- a/home/api.py
+++ b/home/api.py
@@ -1,6 +1,3 @@
-import json
-import pprint as pp
-
 from rest_framework.exceptions import NotFound
 from rest_framework.filters import SearchFilter
 from rest_framework.pagination import PageNumberPagination
@@ -26,9 +23,6 @@ from .models import (  # isort:skip
     TriggeredContent,
 )
 from typing import Any
-
-pp.pprint("Here")
-json.dumps({})
 
 
 class ContentPagesViewSet(PagesAPIViewSet):
@@ -66,92 +60,14 @@ class ContentPagesViewSet(PagesAPIViewSet):
 
         return super().detail_view(request, pk)
 
-    # def listing_view(self, request, *args, **kwargs):
-    #     # If this request is flagged as QA then we should display the pages that have the filtering tags
-    #     # or triggers in their draft versions
-    #     if "qa" in request.GET and request.GET["qa"].lower() == "true":
-    #         tag = self.request.query_params.get("tag")
-    #         trigger = self.request.query_params.get("trigger")
-    #         have_new_triggers = []
-    #         have_new_tags = []
-    #         unpublished = ContentPage.objects.filter(has_unpublished_changes="True")
-    #         for page in unpublished:
-    #             latest_rev = page.get_latest_revision_as_object()
-    #             if trigger and latest_rev.triggers.filter(name=trigger).exists():
-    #                 have_new_triggers.append(page.id)
-    #             if tag and latest_rev.tags.filter(name=tag).exists():
-    #                 have_new_tags.append(page.id)
-
-    #         queryset = self.get_queryset()
-    #         self.check_query_parameters(queryset)
-    #         queryset = self.filter_queryset(queryset)
-    #         queryset = queryset | ContentPage.objects.filter(id__in=have_new_triggers)
-    #         queryset = queryset | ContentPage.objects.filter(id__in=have_new_tags)
-    #         queryset_list = self.paginate_queryset(queryset)
-    #         serializer = self.get_serializer(queryset_list, many=True)
-    #         return self.get_paginated_response(serializer.data)
-
-    #     return super().listing_view(request)
-
     def get_queryset(self) -> Any:
         qa = self.request.query_params.get("qa", "").lower() == "true"
 
         if qa:
-            print("Is QA")
             # return the latest revision for each ContentPage
             queryset = ContentPage.objects.all().order_by("latest_revision_id")
-            for cp in queryset:
-                print("")
-                print(
-                    f"Found content page with title = {cp.title}, latest_revision_id = {cp.latest_revision_id}, live_rev_id = {cp.live_revision_id}, message={cp.whatsapp_body[0].value['message']} "
-                )
-                print(cp.whatsapp_body[0].value["message"])
-                # pp.pprint(vars(cp))
-                all_revisions = cp.revisions.order_by("-created_at")
-                print(f"Found {len(all_revisions)} revisions for this cp")
-                # for rev in all_revisions:
-                #     print("**********************Found revision")
-                #     print(f"Rev ID = {rev.id}")
-                #     print(
-                #         f"Whatsapp body message for this rev {rev.content["whatsapp_body"]}"
-                #     )
-                # pp.pprint(vars(rev))
-                latest_revision = cp.revisions.order_by("-created_at").first()
-                if latest_revision:
-                    print(f"Found latest revision Id {latest_revision.id}")
-                    latest_revision = latest_revision.as_object()
-                    # set the assessment's details to that of the latest revision
-                    # cp = latest_revision
-                    print(f"WA BODY LENGTH: {len(cp.whatsapp_body)}")
-                    print(f"MESSAGE BEFORE: {cp.whatsapp_body[0].value['message']}")
-                    cp.whatsapp_body[0].value["message"] = "wtf"
-                    print(f"MESSAGE AFTER: {cp.whatsapp_body[0].value['message']}")
-                    # content_page.slug = latest_revision.slug
-                    # content_page.version = latest_revision.version
-                    # content_page.locale = latest_revision.locale
-                else:
-                    print("NO REVISION FOUND")
-            # queryset = ContentPage.objects.not_live().prefetch_related("locale")
-            # queryset = ContentPage.objects
         else:
-            print("Is not QA")
             queryset = ContentPage.objects.live()
-            for item in queryset:
-                print(f"ITEM ID IS {item.id}")
-                print(f"ITEM title = {item.title}")
-                print(f"ITEM message = {item.whatsapp_body[0].value['message']}")
-                print("ITEM VARS BELOW")
-                # print(f"ITEM vars = {vars(item)}")
-                # print(json.dumps(item, indent=2))
-                pp.pprint(vars(item), indent=2)
-
-        for cp in queryset:
-            print(f" CP BEFORE PREFETCH: {cp.whatsapp_body[0].value['message']}")
-
-        # queryset = queryset.prefetch_related("locale")
-
-        for cp in queryset:
-            print(f" CP AFTER PREFETCH: {cp.whatsapp_body[0].value['message']}")
 
         if "web" in self.request.query_params:
             queryset = queryset.filter(enable_web=True)

--- a/home/api.py
+++ b/home/api.py
@@ -85,7 +85,6 @@ class ContentPagesViewSet(PagesAPIViewSet):
             ids = []
             for t in ContentPageTag.objects.filter(tag__name__iexact=tag):
                 ids.append(t.content_object_id)
-            print(f"IDs = {ids}")
             queryset = queryset.filter(id__in=ids)
         trigger = self.request.query_params.get("trigger")
         if trigger is not None:

--- a/home/api.py
+++ b/home/api.py
@@ -65,30 +65,27 @@ class ContentPagesViewSet(PagesAPIViewSet):
         queryset = ContentPage.objects.live().prefetch_related("locale")
 
         if qa:
-            # print("QA = true")
-            # return the latest revision for each ContentPage
-            queryset = queryset | ContentPage.objects.not_live().order_by(
-                "latest_revision_id"
-            )
+            queryset = queryset | ContentPage.objects.not_live()
 
-            if "web" in self.request.query_params:
-                queryset = queryset.filter(enable_web=True)
-            elif "whatsapp" in self.request.query_params:
-                queryset = queryset.filter(enable_whatsapp=True)
-            elif "sms" in self.request.query_params:
-                queryset = queryset.filter(enable_sms=True)
-            elif "ussd" in self.request.query_params:
-                queryset = queryset.filter(enable_ussd=True)
-            elif "messenger" in self.request.query_params:
-                queryset = queryset.filter(enable_messenger=True)
-            elif "viber" in self.request.query_params:
-                queryset = queryset.filter(enable_viber=True)
+        if "web" in self.request.query_params:
+            queryset = queryset.filter(enable_web=True)
+        elif "whatsapp" in self.request.query_params:
+            queryset = queryset.filter(enable_whatsapp=True)
+        elif "sms" in self.request.query_params:
+            queryset = queryset.filter(enable_sms=True)
+        elif "ussd" in self.request.query_params:
+            queryset = queryset.filter(enable_ussd=True)
+        elif "messenger" in self.request.query_params:
+            queryset = queryset.filter(enable_messenger=True)
+        elif "viber" in self.request.query_params:
+            queryset = queryset.filter(enable_viber=True)
 
         tag = self.request.query_params.get("tag")
         if tag:
             ids = []
             for t in ContentPageTag.objects.filter(tag__name__iexact=tag):
                 ids.append(t.content_object_id)
+            print(f"IDs = {ids}")
             queryset = queryset.filter(id__in=ids)
         trigger = self.request.query_params.get("trigger")
         if trigger is not None:

--- a/home/api.py
+++ b/home/api.py
@@ -91,8 +91,10 @@ class ContentPagesViewSet(PagesAPIViewSet):
         queryset = ContentPage.objects.live().prefetch_related("locale")
 
         if qa:
-            print("If QA")
+            print("Is QA")
             queryset = queryset | ContentPage.objects.not_live()
+        else:
+            print("Is not QA")
 
         if "web" in self.request.query_params:
             queryset = queryset.filter(enable_web=True)

--- a/home/api.py
+++ b/home/api.py
@@ -59,42 +59,45 @@ class ContentPagesViewSet(PagesAPIViewSet):
 
         return super().detail_view(request, pk)
 
-    def listing_view(self, request, *args, **kwargs):
-        # If this request is flagged as QA then we should display the pages that have the filtering tags
-        # or triggers in their draft versions
-        if "qa" in request.GET and request.GET["qa"].lower() == "true":
-            tag = self.request.query_params.get("tag")
-            trigger = self.request.query_params.get("trigger")
-            have_new_triggers = []
-            have_new_tags = []
-            unpublished = ContentPage.objects.filter(has_unpublished_changes="True")
-            for page in unpublished:
-                latest_rev = page.get_latest_revision_as_object()
-                if trigger and latest_rev.triggers.filter(name=trigger).exists():
-                    have_new_triggers.append(page.id)
-                if tag and latest_rev.tags.filter(name=tag).exists():
-                    have_new_tags.append(page.id)
+    # def listing_view(self, request, *args, **kwargs):
+    #     # If this request is flagged as QA then we should display the pages that have the filtering tags
+    #     # or triggers in their draft versions
+    #     if "qa" in request.GET and request.GET["qa"].lower() == "true":
+    #         tag = self.request.query_params.get("tag")
+    #         trigger = self.request.query_params.get("trigger")
+    #         have_new_triggers = []
+    #         have_new_tags = []
+    #         unpublished = ContentPage.objects.filter(has_unpublished_changes="True")
+    #         for page in unpublished:
+    #             latest_rev = page.get_latest_revision_as_object()
+    #             if trigger and latest_rev.triggers.filter(name=trigger).exists():
+    #                 have_new_triggers.append(page.id)
+    #             if tag and latest_rev.tags.filter(name=tag).exists():
+    #                 have_new_tags.append(page.id)
 
-            queryset = self.get_queryset()
-            self.check_query_parameters(queryset)
-            queryset = self.filter_queryset(queryset)
-            queryset = queryset | ContentPage.objects.filter(id__in=have_new_triggers)
-            queryset = queryset | ContentPage.objects.filter(id__in=have_new_tags)
-            queryset_list = self.paginate_queryset(queryset)
-            serializer = self.get_serializer(queryset_list, many=True)
-            return self.get_paginated_response(serializer.data)
+    #         queryset = self.get_queryset()
+    #         self.check_query_parameters(queryset)
+    #         queryset = self.filter_queryset(queryset)
+    #         queryset = queryset | ContentPage.objects.filter(id__in=have_new_triggers)
+    #         queryset = queryset | ContentPage.objects.filter(id__in=have_new_tags)
+    #         queryset_list = self.paginate_queryset(queryset)
+    #         serializer = self.get_serializer(queryset_list, many=True)
+    #         return self.get_paginated_response(serializer.data)
 
-        return super().listing_view(request)
+    #     return super().listing_view(request)
 
     def get_queryset(self):
-        qa = self.request.query_params.get("qa")
-        queryset = ContentPage.objects.live().prefetch_related("locale")
+        qa = self.request.query_params.get("qa", "").lower() == "true"
 
         if qa:
             print("Is QA")
-            queryset = queryset | ContentPage.objects.not_live()
+            # queryset = ContentPage.objects.not_live().prefetch_related("locale")
+            queryset = ContentPage.objects
         else:
             print("Is not QA")
+            queryset = ContentPage.objects.live()
+
+        queryset = queryset.prefetch_related("locale")
 
         if "web" in self.request.query_params:
             queryset = queryset.filter(enable_web=True)

--- a/home/api.py
+++ b/home/api.py
@@ -62,25 +62,27 @@ class ContentPagesViewSet(PagesAPIViewSet):
 
     def get_queryset(self) -> Any:
         qa = self.request.query_params.get("qa", "").lower() == "true"
+        queryset = ContentPage.objects.live().prefetch_related("locale")
 
         if qa:
+            # print("QA = true")
             # return the latest revision for each ContentPage
-            queryset = ContentPage.objects.all().order_by("latest_revision_id")
-        else:
-            queryset = ContentPage.objects.live()
+            queryset = queryset | ContentPage.objects.not_live().order_by(
+                "latest_revision_id"
+            )
 
-        if "web" in self.request.query_params:
-            queryset = queryset.filter(enable_web=True)
-        elif "whatsapp" in self.request.query_params:
-            queryset = queryset.filter(enable_whatsapp=True)
-        elif "sms" in self.request.query_params:
-            queryset = queryset.filter(enable_sms=True)
-        elif "ussd" in self.request.query_params:
-            queryset = queryset.filter(enable_ussd=True)
-        elif "messenger" in self.request.query_params:
-            queryset = queryset.filter(enable_messenger=True)
-        elif "viber" in self.request.query_params:
-            queryset = queryset.filter(enable_viber=True)
+            if "web" in self.request.query_params:
+                queryset = queryset.filter(enable_web=True)
+            elif "whatsapp" in self.request.query_params:
+                queryset = queryset.filter(enable_whatsapp=True)
+            elif "sms" in self.request.query_params:
+                queryset = queryset.filter(enable_sms=True)
+            elif "ussd" in self.request.query_params:
+                queryset = queryset.filter(enable_ussd=True)
+            elif "messenger" in self.request.query_params:
+                queryset = queryset.filter(enable_messenger=True)
+            elif "viber" in self.request.query_params:
+                queryset = queryset.filter(enable_viber=True)
 
         tag = self.request.query_params.get("tag")
         if tag:
@@ -320,6 +322,5 @@ api_router.register_endpoint("indexes", ContentPageIndexViewSet)
 api_router.register_endpoint("images", ImagesAPIViewSet)
 api_router.register_endpoint("documents", DocumentsAPIViewSet)
 api_router.register_endpoint("media", MediaAPIViewSet)
-# api_router.register_endpoint("whatsapptemplates", WhatsAppTemplateViewset)
 api_router.register_endpoint("orderedcontent", OrderedContentSetViewSet)
 api_router.register_endpoint("assessment", AssessmentViewSet)

--- a/home/api.py
+++ b/home/api.py
@@ -1,3 +1,6 @@
+import json
+import pprint as pp
+
 from rest_framework.exceptions import NotFound
 from rest_framework.filters import SearchFilter
 from rest_framework.pagination import PageNumberPagination
@@ -22,6 +25,9 @@ from .models import (  # isort:skip
     ContentPageTag,
     TriggeredContent,
 )
+
+pp.pprint("Here")
+json.dumps({})
 
 
 class ContentPagesViewSet(PagesAPIViewSet):
@@ -91,11 +97,49 @@ class ContentPagesViewSet(PagesAPIViewSet):
 
         if qa:
             print("Is QA")
+            # return the latest revision for each ContentPage
+            queryset = ContentPage.objects.all().order_by("latest_revision_id")
+            for cp in queryset:
+                print("")
+                print(
+                    f"Found content page with title = {cp.title}, latest_revision_id = {cp.latest_revision_id}, live_rev_id = {cp.live_revision_id}, message={cp.whatsapp_body[0].value["message"]} "
+                )
+                print(cp.whatsapp_body[0].value["message"])
+                # pp.pprint(vars(cp))
+                all_revisions = cp.revisions.order_by("-created_at")
+                print(f"Found {len(all_revisions)} revisions for this cp")
+                # for rev in all_revisions:
+                #     print("**********************Found revision")
+                #     print(f"Rev ID = {rev.id}")
+                #     print(
+                #         f"Whatsapp body message for this rev {rev.content["whatsapp_body"]}"
+                #     )
+                # pp.pprint(vars(rev))
+                latest_revision = cp.revisions.order_by("-created_at").first()
+                if latest_revision:
+                    print(f"Found latest revision Id {latest_revision.id}")
+                    latest_revision = latest_revision.as_object()
+                    # set the assessment's details to that of the latest revision
+                    # cp = latest_revision
+                    cp.whatsapp_body[0].value["message"] = "wtf"
+                    # content_page.slug = latest_revision.slug
+                    # content_page.version = latest_revision.version
+                    # content_page.locale = latest_revision.locale
+                else:
+                    print("NO REVISION FOUND")
             # queryset = ContentPage.objects.not_live().prefetch_related("locale")
-            queryset = ContentPage.objects
+            # queryset = ContentPage.objects
         else:
             print("Is not QA")
             queryset = ContentPage.objects.live()
+            for item in queryset:
+                print(f"ITEM ID IS {item.id}")
+                print(f"ITEM title = {item.title}")
+                print(f"ITEM message = {item.whatsapp_body[0].value['message']}")
+                print("ITEM VARS BELOW")
+                # print(f"ITEM vars = {vars(item)}")
+                # print(json.dumps(item, indent=2))
+                pp.pprint(vars(item), indent=2)
 
         queryset = queryset.prefetch_related("locale")
 

--- a/home/api.py
+++ b/home/api.py
@@ -62,7 +62,7 @@ class ContentPagesViewSet(PagesAPIViewSet):
     def listing_view(self, request, *args, **kwargs):
         # If this request is flagged as QA then we should display the pages that have the filtering tags
         # or triggers in their draft versions
-        if "qa" in request.GET and request.GET["qa"] == "True":
+        if "qa" in request.GET and request.GET["qa"].lower() == "true":
             tag = self.request.query_params.get("tag")
             trigger = self.request.query_params.get("trigger")
             have_new_triggers = []
@@ -91,6 +91,7 @@ class ContentPagesViewSet(PagesAPIViewSet):
         queryset = ContentPage.objects.live().prefetch_related("locale")
 
         if qa:
+            print("If QA")
             queryset = queryset | ContentPage.objects.not_live()
 
         if "web" in self.request.query_params:

--- a/home/api_v3.py
+++ b/home/api_v3.py
@@ -37,7 +37,7 @@ class WhatsAppTemplateViewset(BaseAPIViewSet):
             self.lookup_field = "slug"
 
         try:
-            if "qa" in request.GET and request.GET["qa"] == "True":
+            if "qa" in request.GET and request.GET["qa"].lower() == "true":
                 instance = self.get_object().get_latest_revision_as_object()
             else:
                 instance = self.get_object()
@@ -140,7 +140,7 @@ class ContentPagesV3APIViewset(PagesAPIViewSet):
     def listing_view(self, request, *args, **kwargs):
         # If this request is flagged as QA then we should display the pages that have the filtering tags
         # or triggers in their draft versions
-        if "qa" in request.GET and request.GET["qa"] == "True":
+        if "qa" in request.GET and request.GET["qa"].lower() == "true":
             tag = self.request.query_params.get("tag")
             trigger = self.request.query_params.get("trigger")
             have_new_triggers = []

--- a/home/api_v3.py
+++ b/home/api_v3.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.urls import path
 from rest_framework.exceptions import NotFound
 from rest_framework.filters import SearchFilter
@@ -14,6 +16,8 @@ from .models import (  # isort:skip
     TriggeredContent,
     WhatsAppTemplate,
 )
+
+import pprint as pp
 
 
 class WhatsAppTemplateViewset(BaseAPIViewSet):
@@ -103,14 +107,9 @@ class ContentPagesV3APIViewset(PagesAPIViewSet):
             "tag",
             "trigger",
             "page",
-            "qa",
-            "whatsapp",
-            "viber",
-            "messenger",
-            "web",
-            "s",
-            "sms",
-            "ussd",
+            "return_drafts",
+            "channel",
+            "slug",
         ]
     )
 
@@ -140,64 +139,98 @@ class ContentPagesV3APIViewset(PagesAPIViewSet):
     def listing_view(self, request, *args, **kwargs):
         # If this request is flagged as QA then we should display the pages that have the filtering tags
         # or triggers in their draft versions
-        if "qa" in request.GET and request.GET["qa"].lower() == "true":
-            tag = self.request.query_params.get("tag")
-            trigger = self.request.query_params.get("trigger")
-            have_new_triggers = []
-            have_new_tags = []
-            # have_new_buttons = []
-            unpublished = ContentPage.objects.filter(has_unpublished_changes="True")
 
-            for page in unpublished:
-                latest_rev = page.get_latest_revision_as_object()
+        queryset = ContentPage.objects.live().prefetch_related("locale")
+        self.check_query_parameters(queryset)
 
-                if trigger and latest_rev.triggers.filter(name=trigger).exists():
-                    have_new_triggers.append(page.id)
-                if tag and latest_rev.tags.filter(name=tag).exists():
-                    have_new_tags.append(page.id)
-
-            queryset = self.get_queryset()
-
-            self.check_query_parameters(queryset)
-            queryset = self.filter_queryset(queryset)
-            queryset = queryset | ContentPage.objects.filter(id__in=have_new_triggers)
-            queryset = queryset | ContentPage.objects.filter(id__in=have_new_tags)
-
-            queryset_list = self.paginate_queryset(queryset)
-
-            serializer = ContentPageSerializerV3(
-                queryset_list, context={"request": request}, many=True
+        return_drafts = (
+            self.request.query_params.get("return_drafts", "").lower() == "true"
+        )
+        if return_drafts:
+            queryset = queryset | ContentPage.objects.all().order_by(
+                "latest_revision_id"
             )
-            return self.get_paginated_response(serializer.data)
 
-        queryset = self.get_queryset()
+        slug = self.request.query_params.get("slug", "").lower()
+        # If a slug is proviced as query param, filter on that
+        if slug != "":
+            for cp in queryset:
+                print(f"CP Title = {cp.title}")
+                print(f"CP Slug = {cp.slug}")
+
+            queryset = queryset.filter(slug=slug)
+
+            print("SLug filteredQUERYSET BELOW ")
+            pp.pprint(queryset)
+
+        # TODO: Check this section properly.  Are these all we need to filter on? Should we add buttons, list items
+        # ************ SECTION START
+
+        tag = self.request.query_params.get("tag")
+        trigger = self.request.query_params.get("trigger")
+        have_new_triggers = []
+        have_new_tags = []
+        # have_new_buttons = []
+        unpublished = ContentPage.objects.filter(has_unpublished_changes="True")
+
+        for page in unpublished:
+            latest_rev = page.get_latest_revision_as_object()
+
+            if trigger and latest_rev.triggers.filter(name=trigger).exists():
+                have_new_triggers.append(page.id)
+            if tag and latest_rev.tags.filter(name=tag).exists():
+                have_new_tags.append(page.id)
+
+        #     queryset = self.get_queryset()
+        # queryset = self.filter_queryset(queryset)
+        queryset = queryset | ContentPage.objects.filter(id__in=have_new_triggers)
+        queryset = queryset | ContentPage.objects.filter(id__in=have_new_tags)
+        print("TagTrig filtered Queryset Below")
+        pp.pprint(queryset)
+
+        # ************ SECTION END
+
         queryset_list = self.paginate_queryset(queryset)
 
         serializer = ContentPageSerializerV3(
             queryset_list, context={"request": request}, many=True
         )
-
         return self.get_paginated_response(serializer.data)
 
-    def get_queryset(self):
-        qa = self.request.query_params.get("qa")
+    def get_queryset(self) -> Any:
+        return_drafts = (
+            self.request.query_params.get("return_drafts", "").lower() == "true"
+        )
         queryset = ContentPage.objects.live().prefetch_related("locale")
 
-        if qa:
+        if return_drafts == "true":
             queryset = queryset | ContentPage.objects.not_live()
 
-        if "web" in self.request.query_params:
-            queryset = queryset.filter(enable_web=True)
-        elif "whatsapp" in self.request.query_params:
-            queryset = queryset.filter(enable_whatsapp=True)
-        elif "sms" in self.request.query_params:
-            queryset = queryset.filter(enable_sms=True)
-        elif "ussd" in self.request.query_params:
-            queryset = queryset.filter(enable_ussd=True)
-        elif "messenger" in self.request.query_params:
-            queryset = queryset.filter(enable_messenger=True)
-        elif "viber" in self.request.query_params:
-            queryset = queryset.filter(enable_viber=True)
+        channel = ""
+        if "channel" in self.request.query_params:
+            channel = self.request.query_params.get("channel", "").lower()
+
+            match channel:
+                case "web":
+                    queryset = queryset.filter(enable_web=True)
+                case "whatsapp":
+                    queryset = queryset.filter(enable_whatsapp=True)
+                case "sms":
+                    queryset = queryset.filter(enable_sms=True)
+                case "ussd":
+                    queryset = queryset.filter(enable_ussd=True)
+                case "messenger":
+                    queryset = queryset.filter(enable_messenger=True)
+                case "viber":
+                    queryset = queryset.filter(enable_viber=True)
+                case _:
+                    raise NotFound(
+                        {
+                            "channel": [
+                                f"channel matching query '{channel}' does not exist."
+                            ]
+                        }
+                    )
 
         tag = self.request.query_params.get("tag")
         if tag:

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -266,11 +266,13 @@ def body_field_representation(page: Any, request: Any) -> Any:
                             and "value" in formatted_message
                             and "message" in formatted_message["value"]
                         ):
-                            formatted_message["value"]["message"] = (
-                                latest_revision.whatsapp_body.raw_data[
-                                    message
-                                ]["value"]["message"]
-                            )  # Your modified message
+                            formatted_message["value"][
+                                "message"
+                            ] = latest_revision.whatsapp_body.raw_data[message][
+                                "value"
+                            ][
+                                "message"
+                            ]  # Your modified message
                     api_body.update(
                         [
                             (

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -290,7 +290,7 @@ def body_field_representation(page: Any, request: Any) -> Any:
             except IndexError:
                 raise ValidationError("The requested message does not exist")
     elif "ussd" in request.GET and (
-        page.enable_ussd is Truerequest.GET["qa"].lower() == "true"
+        page.enable_ussd is True
         or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.ussd_body != []:

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -265,13 +265,11 @@ def body_field_representation(page: Any, request: Any) -> Any:
                             and "value" in formatted_message
                             and "message" in formatted_message["value"]
                         ):
-                            formatted_message["value"][
-                                "message"
-                            ] = latest_revision.whatsapp_body.raw_data[message][
-                                "value"
-                            ][
-                                "message"
-                            ]  # Your modified message
+                            formatted_message["value"]["message"] = (
+                                latest_revision.whatsapp_body.raw_data[
+                                    message
+                                ]["value"]["message"]
+                            )  # Your modified message
                     api_body.update(
                         [
                             (

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -250,11 +250,33 @@ def body_field_representation(page: Any, request: Any) -> Any:
                     )
 
                 elif block["type"] == "Whatsapp_Message":
+                    # Get the formatted message
+                    formatted_message = format_whatsapp_message(
+                        message, page, "whatsapp"
+                    )
+
+                    # If in QA mode, modify the message
+                    if "qa" in request.GET and request.GET["qa"].lower() == "true":
+                        latest_revision = (
+                            page.revisions.order_by("-created_at").first().as_object()
+                        )
+                        if (
+                            isinstance(formatted_message, dict)
+                            and "value" in formatted_message
+                            and "message" in formatted_message["value"]
+                        ):
+                            formatted_message["value"][
+                                "message"
+                            ] = latest_revision.whatsapp_body.raw_data[message][
+                                "value"
+                            ][
+                                "message"
+                            ]  # Your modified message
                     api_body.update(
                         [
                             (
                                 "text",
-                                format_whatsapp_message(message, page, "whatsapp"),
+                                formatted_message,
                             ),
                             ("revision", page.get_latest_revision().id),
                             ("is_whatsapp_template", False),

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -230,6 +230,7 @@ def body_field_representation(page: Any, request: Any) -> Any:
                 )
                 # if it's a template, we need to get the template content
                 block = page.whatsapp_body._raw_data[message]
+
                 if block["type"] == "Whatsapp_Template":
                     template = WhatsAppTemplate.objects.get(id=block["value"])
 

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -209,7 +209,7 @@ def body_field_representation(page: Any, request: Any) -> Any:
 
     if "whatsapp" in request.GET and (
         page.enable_whatsapp is True
-        or ("qa" in request.GET and request.GET["qa"] == "True")
+        or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.whatsapp_body != []:
             try:
@@ -267,7 +267,8 @@ def body_field_representation(page: Any, request: Any) -> Any:
             except IndexError:
                 raise ValidationError("The requested message does not exist")
     elif "sms" in request.GET and (
-        page.enable_sms is True or ("qa" in request.GET and request.GET["qa"] == "True")
+        page.enable_sms is True
+        or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.sms_body != []:
             try:
@@ -289,8 +290,8 @@ def body_field_representation(page: Any, request: Any) -> Any:
             except IndexError:
                 raise ValidationError("The requested message does not exist")
     elif "ussd" in request.GET and (
-        page.enable_ussd is True
-        or ("qa" in request.GET and request.GET["qa"] == "True")
+        page.enable_ussd is Truerequest.GET["qa"].lower() == "true"
+        or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.ussd_body != []:
             try:
@@ -313,7 +314,7 @@ def body_field_representation(page: Any, request: Any) -> Any:
                 raise ValidationError("The requested message does not exist")
     elif "messenger" in request.GET and (
         page.enable_messenger is True
-        or ("qa" in request.GET and request.GET["qa"] == "True")
+        or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.messenger_body != []:
             try:
@@ -336,7 +337,7 @@ def body_field_representation(page: Any, request: Any) -> Any:
                 raise ValidationError("The requested message does not exist")
     elif "viber" in request.GET and (
         page.enable_viber is True
-        or ("qa" in request.GET and request.GET["qa"] == "True")
+        or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.viber_body != []:
             try:

--- a/home/serializers_v3.py
+++ b/home/serializers_v3.py
@@ -1,3 +1,4 @@
+import pprint
 from collections import OrderedDict
 
 from rest_framework import serializers
@@ -7,6 +8,9 @@ from wagtail.api.v2.serializers import PageSerializer
 from wagtail.api.v2.utils import get_object_detail_url
 
 from home.models import Assessment, ContentPage, WhatsAppTemplate
+
+pp = pprint.PrettyPrinter(indent=4, depth=8)
+pp.pprint("Forget me not")
 
 
 def has_next_message(message_index, content_page, platform):
@@ -83,30 +87,35 @@ def format_related_pages(page, request):
 
 
 def format_generic_channel_body(page, channel, message):
-    print(channel)
-    channel_body = getattr(page, f"{channel}_body")
-    if channel_body != []:
-        print("Past geattr")
-        try:
-            print(channel_body._raw_data[message]["value"]["message"])
-            return OrderedDict(
-                [
-                    # TODO: Not sure if we want this or not
-                    # ("message", message + 1),
-                    # (
-                    #     "next_message",
-                    #     has_next_message(message, page, channel),
-                    # ),
-                    # (
-                    #     "previous_message",
-                    #     has_previous_message(message, page, channel),
-                    # ),
-                    # ("total_messages", len(channel_body._raw_data)),
-                    ("text", channel_body._raw_data[message]["value"]["message"]),
-                ]
-            )
-        except IndexError:
-            raise ValidationError("The requested message does not exist")
+    print("********PAGE HERE******")
+    pp.pprint(vars(page))
+    if channel == "web":
+        print("TODO Do web things")
+    else:
+        channel_body = getattr(page, f"{channel}_body")
+        if channel_body != []:
+            print("Past geattr")
+            print(channel_body)
+            try:
+                print(channel_body.raw_data[message]["value"]["message"])
+                return OrderedDict(
+                    [
+                        # TODO: Not sure if we want this or not
+                        # ("message", message + 1),
+                        # (
+                        #     "next_message",
+                        #     has_next_message(message, page, channel),
+                        # ),
+                        # (
+                        #     "previous_message",
+                        #     has_previous_message(message, page, channel),
+                        # ),
+                        # ("total_messages", len(channel_body._raw_data)),
+                        ("text", channel_body._raw_data[message]["value"]["message"]),
+                    ]
+                )
+            except IndexError:
+                raise ValidationError("The requested message does not exist")
 
 
 def format_messages(page, request):
@@ -263,6 +272,18 @@ def format_detail_url(obj, request):
 
 
 class ContentPageSerializerV3(PageSerializer):
+    def __init__(self, *args, **kwargs):
+        print("__init__ - Initializing SerializerV3")
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def many_init(cls, *args, **kwargs):
+        print("many_init - Initializing SerializerV3")
+        # Example: Add a custom_data_for_item to each child serializer
+        # This could be dynamic based on some logic
+
+        return super().many_init(*args, **kwargs)
+
     title = serializers.CharField(read_only=True)
     slug = serializers.SlugField(read_only=True)
     messages = serializers.SerializerMethodField()
@@ -285,13 +306,17 @@ class ContentPageSerializerV3(PageSerializer):
             "related_pages",
         ]
 
-    def get_messages(self, obj):
-        return format_messages(page=obj, request=self.context["request"])
-
     def get_detail_url(self, obj):
+        print("")
+        print(f"SERIALIZERV3 Called get_detail_url(obj = {obj})")
         return format_detail_url(obj=obj, request=self.context["request"])
 
+    def get_messages(self, obj):
+        print(f"SERIALIZERV3 Called get_messages(obj = {obj})")
+        return format_messages(page=obj, request=self.context["request"])
+
     def get_related_pages(self, obj):
+        print(f"SERIALIZERV3 Called get_related_pages(obj = {obj})")
         return format_related_pages(page=obj, request=self.context["request"])
 
 

--- a/home/serializers_v3.py
+++ b/home/serializers_v3.py
@@ -87,17 +87,12 @@ def format_related_pages(page, request):
 
 
 def format_generic_channel_body(page, channel, message):
-    print("********PAGE HERE******")
-    pp.pprint(vars(page))
     if channel == "web":
         print("TODO Do web things")
     else:
         channel_body = getattr(page, f"{channel}_body")
         if channel_body != []:
-            print("Past geattr")
-            print(channel_body)
             try:
-                print(channel_body.raw_data[message]["value"]["message"])
                 return OrderedDict(
                     [
                         # TODO: Not sure if we want this or not
@@ -272,18 +267,6 @@ def format_detail_url(obj, request):
 
 
 class ContentPageSerializerV3(PageSerializer):
-    def __init__(self, *args, **kwargs):
-        print("__init__ - Initializing SerializerV3")
-        super().__init__(*args, **kwargs)
-
-    @classmethod
-    def many_init(cls, *args, **kwargs):
-        print("many_init - Initializing SerializerV3")
-        # Example: Add a custom_data_for_item to each child serializer
-        # This could be dynamic based on some logic
-
-        return super().many_init(*args, **kwargs)
-
     title = serializers.CharField(read_only=True)
     slug = serializers.SlugField(read_only=True)
     messages = serializers.SerializerMethodField()
@@ -307,16 +290,12 @@ class ContentPageSerializerV3(PageSerializer):
         ]
 
     def get_detail_url(self, obj):
-        print("")
-        print(f"SERIALIZERV3 Called get_detail_url(obj = {obj})")
         return format_detail_url(obj=obj, request=self.context["request"])
 
     def get_messages(self, obj):
-        print(f"SERIALIZERV3 Called get_messages(obj = {obj})")
         return format_messages(page=obj, request=self.context["request"])
 
     def get_related_pages(self, obj):
-        print(f"SERIALIZERV3 Called get_related_pages(obj = {obj})")
         return format_related_pages(page=obj, request=self.context["request"])
 
 

--- a/home/serializers_v3.py
+++ b/home/serializers_v3.py
@@ -116,7 +116,7 @@ def format_messages(page, request):
             except IndexError:
                 raise ValidationError("The requested message does not exist")
     elif "ussd" in request.GET and (
-        page.enable_ussd is Truerequest.GET["qa"].lower() == "true"
+        page.enable_ussd is True
         or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.ussd_body != []:
@@ -139,7 +139,7 @@ def format_messages(page, request):
             except IndexError:
                 raise ValidationError("The requested message does not exist")
     elif "messenger" in request.GET and (
-        page.enable_messenger is Trurequest.GET["qa"].lower() == "true"
+        page.enable_messenger is True
         or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.messenger_body != []:
@@ -162,7 +162,7 @@ def format_messages(page, request):
             except IndexError:
                 raise ValidationError("The requested message does not exist")
     elif "viber" in request.GET and (
-        page.enable_viber is Truerequest.GET["qa"].lower() == "true"
+        page.enable_viber is True
         or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.viber_body != []:

--- a/home/serializers_v3.py
+++ b/home/serializers_v3.py
@@ -86,14 +86,15 @@ def format_messages(page, request):
     message = 0
     if "whatsapp" in request.GET and (
         page.enable_whatsapp is True
-        or ("qa" in request.GET and request.GET["qa"] == "True")
+        or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.whatsapp_body != []:
             whatsapp_messages = format_whatsapp_body_V3(page)
             return whatsapp_messages
 
     elif "sms" in request.GET and (
-        page.enable_sms is True or ("qa" in request.GET and request.GET["qa"] == "True")
+        page.enable_sms is True
+        or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.sms_body != []:
             try:
@@ -115,8 +116,8 @@ def format_messages(page, request):
             except IndexError:
                 raise ValidationError("The requested message does not exist")
     elif "ussd" in request.GET and (
-        page.enable_ussd is True
-        or ("qa" in request.GET and request.GET["qa"] == "True")
+        page.enable_ussd is Truerequest.GET["qa"].lower() == "true"
+        or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.ussd_body != []:
             try:
@@ -138,8 +139,8 @@ def format_messages(page, request):
             except IndexError:
                 raise ValidationError("The requested message does not exist")
     elif "messenger" in request.GET and (
-        page.enable_messenger is True
-        or ("qa" in request.GET and request.GET["qa"] == "True")
+        page.enable_messenger is Trurequest.GET["qa"].lower() == "true"
+        or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.messenger_body != []:
             try:
@@ -161,8 +162,8 @@ def format_messages(page, request):
             except IndexError:
                 raise ValidationError("The requested message does not exist")
     elif "viber" in request.GET and (
-        page.enable_viber is True
-        or ("qa" in request.GET and request.GET["qa"] == "True")
+        page.enable_viber is Truerequest.GET["qa"].lower() == "true"
+        or ("qa" in request.GET and request.GET["qa"].lower() == "true")
     ):
         if page.viber_body != []:
             try:

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -1,4 +1,5 @@
 import json
+import pprint as pp
 import queue
 from pathlib import Path
 from typing import Any
@@ -368,6 +369,30 @@ class TestContentPageAPI:
         assert not page.live
         body = content["body"]["text"]["message"]
         assert body == f"*Default {platform} Content 1* 🏥"
+
+    # @pytest.mark.parametrize("platform", ALL_PLATFORMS_EXCL_WHATSAPP)
+    # def test_message_draft_by_slug_qa_lowercase(self, uclient, platform):
+    def test_message_draft_by_slug_qa_lowercase(self, uclient):
+        """
+        Unpublished <platform> pages are returned if the qa param is set.
+        """
+        page = self.create_content_page(
+            title="I am draft lowercase", publish=False, body_type="whatsapp"
+        )
+        print(f"Page = {page.slug}")
+        # url = f"/api/v2/pages/?slug={page.slug}&{platform}=True&qa=True"
+        url = f"/api/v2/pages/?slug={page.slug}&whatsapp=True&qa=True"
+        # it should return specific page that is in draft
+        response = uclient.get(url)
+        print(f"Response is {response}")
+        content = response.json()
+        pp.pprint(content["body"])
+
+        # the page is not live but messenger content is returned
+        assert not page.live
+        body = content["body"]["text"]["message"]
+        # assert body == f"*Default {platform} Content 1* 🏥"
+        assert body == "*Default whatsapp Content 1* 🏥"
 
     @pytest.mark.parametrize("platform", ALL_PLATFORMS)
     def test_platform_disabled(self, uclient, platform):

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -393,21 +393,40 @@ class TestContentPageAPI:
         # live page.
         page3.whatsapp_body[0].value["message"] = "p3 draft 1"
         page3.save_revision()
-        page3.save()
-        pp.pprint(f"page3.live={page3.live} page3.has_unpublished_changes={page3.has_unpublished_changes}")
-        response = uclient.get("/api/v2/pages/?whatsapp=true&qa=true")
-        [p1, p2, p3] = response.json()["results"]
+        # page3.save()
+        # pp.pprint(
+        #     f"page3.live={page3.live} page3.has_unpublished_changes={page3.has_unpublished_changes} & message = {page3.whatsapp_body[0].value["message"]}"
+        # )
+        qa_response = uclient.get("/api/v2/pages/?whatsapp=true&qa=true")
+        [q1, q2, q3] = qa_response.json()["results"]
+        # pp.pprint(qa_response.json()["results"])
+        print("********")
+        # pp.pprint(q3)
+        # for item in qa_response:
+        #     print("")
+        #     print("Item found")
+        #     # print(item)
+        #     pp.pprint(item)
+        # print(p3["body"]["text"]["value"]["message"])
+        assert q1["body"]["text"]["value"]["message"] == "p1 draft 1"
+        assert q2["body"]["text"]["value"]["message"] == "p2 live 1"
+        assert q3["body"]["text"]["value"]["message"] == "p3 draft 1"
 
-        assert p1["body"]["text"]["value"]["message"] == "p1 draft 1"
-        assert p2["body"]["text"]["value"]["message"] == "p2 live 1"
-        assert p3["body"]["text"]["value"]["message"] == "p3 draft 1"
+        print("")
+        print("Done with QA")
+        print("")
 
-        response = uclient.get("/api/v2/pages/?whatsapp=true")
-        [p2, p3] = response.json()["results"]
-        assert p2["body"]["text"]["value"]["message"] == "p2 live 1"
+        live_response = uclient.get("/api/v2/pages/?whatsapp=true")
+        print("Live Reponse")
+        pp.pprint(live_response.json()["results"])
+
+        [l2, l3] = live_response.json()["results"]
+        assert l2["body"]["text"]["value"]["message"] == "p2 live 1"
         # The following _should_ return the live content for page3, but
         # apparently returns the draft content instead.
-        assert p3["body"]["text"]["value"]["message"] == "p3 live 1"
+        print("1")
+        assert l3["body"]["text"]["value"]["message"] == "p3 live 1"
+        print("2")
         assert False
 
     @pytest.mark.parametrize("platform", ALL_PLATFORMS)

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -575,7 +575,7 @@ class TestContentPageAPI:
         page = self.create_content_page()
         page = self.create_content_page(page, title="Content Page 1")
         uclient.get("/api/v2/pages/")
-        with django_assert_num_queries(16):
+        with django_assert_num_queries(17):
             uclient.get("/api/v2/pages/")
 
     @pytest.mark.parametrize("platform", ALL_PLATFORMS)

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -382,10 +382,10 @@ class TestContentPageAPI:
         """
         Unpublished <platform> pages are returned if the qa param is set.
         """
-        page1 = self.create_content_page(
+        self.create_content_page(
             title="page1", publish=False, body_type="whatsapp", msg_prefix="p1 draft"
         )
-        page2 = self.create_content_page(
+        self.create_content_page(
             title="page2", publish=True, body_type="whatsapp", msg_prefix="p2 live"
         )
         page3 = self.create_content_page(
@@ -395,21 +395,10 @@ class TestContentPageAPI:
         # live page.
         page3.whatsapp_body[0].value["message"] = "p3 draft 1"
         page3.save_revision()
-        # page3.save()
-        # pp.pprint(
-        #     f"page3.live={page3.live} page3.has_unpublished_changes={page3.has_unpublished_changes} & message = {page3.whatsapp_body[0].value["message"]}"
-        # )
+
         qa_response = uclient.get("/api/v2/pages/?whatsapp=true&qa=true")
         [q1, q2, q3] = qa_response.json()["results"]
-        # pp.pprint(qa_response.json()["results"])
-        print("********")
-        # pp.pprint(q3)
-        # for item in qa_response:
-        #     print("")
-        #     print("Item found")
-        #     # print(item)
-        #     pp.pprint(item)
-        # print(p3["body"]["text"]["value"]["message"])
+
         assert q1["body"]["text"]["value"]["message"] == "p1 draft 1"
         assert q2["body"]["text"]["value"]["message"] == "p2 live 1"
         assert q3["body"]["text"]["value"]["message"] == "p3 draft 1"

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -267,6 +267,7 @@ class TestContentPageAPI:
         # same tag
         response = uclient.get("/api/v2/pages/?tag=menu")
         content = json.loads(response.content)
+        pp.pprint(content)
         assert content["count"] == 1
 
         # it should return 1 page for Uppercase tag
@@ -308,6 +309,7 @@ class TestContentPageAPI:
         # it should return only web pages if filtered
         response = uclient.get("/api/v2/pages/?web=true")
         content = json.loads(response.content)
+        pp.pprint(content)
         assert content["count"] == 1
 
         # it should return only whatsapp pages if filtered
@@ -575,7 +577,7 @@ class TestContentPageAPI:
         page = self.create_content_page()
         page = self.create_content_page(page, title="Content Page 1")
         uclient.get("/api/v2/pages/")
-        with django_assert_num_queries(17):
+        with django_assert_num_queries(16):
             uclient.get("/api/v2/pages/")
 
     @pytest.mark.parametrize("platform", ALL_PLATFORMS)

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -376,7 +376,7 @@ class TestContentPageAPI:
 
     # @pytest.mark.parametrize("platform", ALL_PLATFORMS_EXCL_WHATSAPP)
     # def test_message_draft_by_slug_qa_lowercase(self, uclient, platform):
-    def test_message_draft_by_slug_qa_lowercase(self, uclient):
+    def test_message_draft_by_slug_qa_lowercase(self, uclient: Any) -> None:
         """
         Unpublished <platform> pages are returned if the qa param is set.
         """
@@ -424,10 +424,7 @@ class TestContentPageAPI:
         assert l2["body"]["text"]["value"]["message"] == "p2 live 1"
         # The following _should_ return the live content for page3, but
         # apparently returns the draft content instead.
-        print("1")
         assert l3["body"]["text"]["value"]["message"] == "p3 live 1"
-        print("2")
-        assert False
 
     @pytest.mark.parametrize("platform", ALL_PLATFORMS)
     def test_platform_disabled(self, uclient, platform):

--- a/home/tests/test_api_v3.py
+++ b/home/tests/test_api_v3.py
@@ -391,8 +391,10 @@ class TestContentPageAPIV3:
 
         assert response.status_code == 404
         content = json.loads(response.content)
-        print(content.get("page"))
-        assert content.get("page") == ["Page matching query does not exist."]
+
+        assert (
+            content["channel"][0] == "channel matching query 'unknown' does not exist."
+        )
 
     def test_number_of_queries(self, uclient, django_assert_num_queries):
         """
@@ -406,7 +408,8 @@ class TestContentPageAPIV3:
         page = self.create_content_page()
         page = self.create_content_page(page, title="Content Page 1")
         uclient.get("/api/v3/pages/")
-        with django_assert_num_queries(16):
+        # TODO: Keep an eye on this chang from 16 to 10.
+        with django_assert_num_queries(10):
             uclient.get("/api/v3/pages/")
 
     @pytest.mark.parametrize("platform", ALL_PLATFORMS)


### PR DESCRIPTION
## Purpose
During our work on the Standalone Templates API, we picked up some bugs in the parameter filtering code, and that the code was too complex and fragmented to do an easy fix.   

## Solution
We decided to refactor the code to run in memory, rather than making multiple queries at different stages

#### Checklist
- [ ] Added or updated unit tests
- [ ] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
