### PR TITLE
Fix search for Ordered Content Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix go_to_page item validation
+- Fix Ordered Content Set search
 
 ### Security
 -->

--- a/home/models.py
+++ b/home/models.py
@@ -1104,9 +1104,9 @@ class OrderedContentSet(
     )
     search_fields = [
         index.SearchField("name"),
-        index.SearchField("get_gender"),
-        index.SearchField("get_age"),
-        index.SearchField("get_relationship"),
+        index.AutocompleteField("name"),
+        index.SearchField("profile_fields"),
+        index.AutocompleteField("profile_fields"),
     ]
     pages = StreamField(
         [

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -404,6 +404,61 @@ class OrderedContentSetTests(TestCase):
 
         assert ordered_content_set.status() == "In Moderation"
 
+    def test_search_fields_include_profile_fields(self) -> None:
+        """
+        OrderedContentSet search config should index concrete fields used by the
+        snippets listing search.
+        """
+        search_fields = {
+            (search_field.__class__.__name__, search_field.field_name)
+            for search_field in OrderedContentSet.search_fields
+        }
+
+        self.assertSetEqual(
+            search_fields,
+            {
+                ("SearchField", "name"),
+                ("AutocompleteField", "name"),
+                ("SearchField", "profile_fields"),
+                ("AutocompleteField", "profile_fields"),
+            },
+        )
+
+    def test_search_fields_do_not_use_profile_methods(self) -> None:
+        """
+        Search indexing must not use model methods because DB-backed search expects
+        concrete fields.
+        """
+        indexed_names = {
+            search_field.field_name for search_field in OrderedContentSet.search_fields
+        }
+        self.assertFalse({"get_gender", "get_age", "get_relationship"} & indexed_names)
+
+    def test_admin_search_returns_only_matching_ordered_content_set(self) -> None:
+        """
+        Admin snippets search should return only OrderedContentSet instances matching
+        the search query.
+        """
+        User.objects.create_superuser(
+            username="admin",
+            email="admin@example.com",
+            password="pass",  # noqa: S106
+        )
+        self.client.login(username="admin", password="pass")  # noqa: S106
+
+        locale = Locale.objects.get(language_code="en")
+        OrderedContentSet.objects.create(name="Hello", slug="hello", locale=locale)
+        OrderedContentSet.objects.create(name="Goodbye", slug="goodbye", locale=locale)
+
+        response = self.client.get(
+            "/admin/snippets/home/orderedcontentset/", {"q": "He"}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("Hello", content)
+        self.assertNotIn("Goodbye", content)
+
 
 class WhatsappBlockTests(TestCase):
     def create_message_value(

--- a/home/views.py
+++ b/home/views.py
@@ -9,7 +9,7 @@ import django_filters
 import markdown
 from django.contrib import messages
 from django.db import connection as db_connection
-from django.db.models import Count, F
+from django.db.models import Count, F, Q
 from django.db.models.functions import TruncMonth
 from django.forms import MultiWidget
 from django.forms.widgets import NumberInput
@@ -87,7 +87,13 @@ class CustomIndexViewWhatsAppTemplate(
 
 
 class CustomIndexViewOrdered(SpreadsheetExportMixinOrdered, IndexViewOrdered):
-    pass
+    def search_queryset(self, queryset):
+        if self.search_query:
+            return queryset.filter(
+                Q(name__icontains=self.search_query)
+                | Q(profile_fields__icontains=self.search_query)
+            )
+        return queryset
 
 
 class WhatsAppTemplateChooseView(ChooseView):

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -264,7 +264,6 @@ class OrderedContentSetViewSet(SnippetViewSet):
     export_headings = {"language_code": "Locale"}
 
     list_filter = ("locale",)
-    search_fields = ("name", "profile_fields")
 
 
 class WhatsAppTemplateAdmin(SnippetViewSet):


### PR DESCRIPTION
## Purpose
Search on Ordered Content Sets is currently broken. Searching causes an exception.

## Solution
This fixes the search functionality, and adds some basic tests for it.

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
