### PR TITLE
Fix WhatsApp Template search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix go_to_page item validation
 - Fix Ordered Content Set search
+- Fix WhatsApp Template search
 
 ### Security
 -->

--- a/home/models.py
+++ b/home/models.py
@@ -1585,10 +1585,13 @@ class WhatsAppTemplate(
         index.SearchField("category"),
         index.SearchField("message"),
         index.AutocompleteField("message"),
+        index.SearchField("locale"),
+        index.AutocompleteField("locale"),
         index.RelatedFields(
             "locale",
             [
                 index.SearchField("language_code"),
+                index.AutocompleteField("language_code"),
             ],
         ),
     ]

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -34,6 +34,7 @@ from home.models import (
     WhatsappBlock,
     WhatsAppTemplate,
 )
+from home.views import CustomIndexViewWhatsAppTemplate
 from home.whatsapp import submit_to_meta_action
 
 from .page_builder import PageBtn, PageBuilder, WABlk, WABody
@@ -624,6 +625,53 @@ class SMSBlockTests(TestCase):
 
 @pytest.mark.django_db
 class WhatsAppTemplateTests(TestCase):
+    def test_search_queryset_matches_locale_queries(self) -> None:
+        """
+        WhatsAppTemplate snippets search should match locale code and language
+        name fragments.
+        """
+        en_locale = Locale.objects.get(language_code="en")
+        pt_locale = Locale.objects.create(language_code="pt")
+        WhatsAppTemplate.objects.create(
+            slug="english-template",
+            message="English template",
+            category=WhatsAppTemplate.Category.UTILITY,
+            locale=en_locale,
+        )
+        WhatsAppTemplate.objects.create(
+            slug="portuguese-template",
+            message="Portuguese template",
+            category=WhatsAppTemplate.Category.UTILITY,
+            locale=pt_locale,
+        )
+
+        view = CustomIndexViewWhatsAppTemplate()
+
+        view.search_query = "en"
+        en_results = set(
+            view.search_queryset(WhatsAppTemplate.objects.all()).values_list(
+                "slug", flat=True
+            )
+        )
+        self.assertIn("english-template", en_results)
+        self.assertNotIn("portuguese-template", en_results)
+
+        view.search_query = "pt"
+        pt_results = set(
+            view.search_queryset(WhatsAppTemplate.objects.all()).values_list(
+                "slug", flat=True
+            )
+        )
+        self.assertIn("portuguese-template", pt_results)
+
+        view.search_query = "po"
+        po_results = set(
+            view.search_queryset(WhatsAppTemplate.objects.all()).values_list(
+                "slug", flat=True
+            )
+        )
+        self.assertIn("portuguese-template", po_results)
+
     @override_settings(WHATSAPP_ALLOW_NAMED_VARIABLES=False)
     def test_whitespace_in_positional_variables_are_invalid(self) -> None:
         """

--- a/home/tests/test_whatsapp_template_chooser.py
+++ b/home/tests/test_whatsapp_template_chooser.py
@@ -59,7 +59,8 @@ class TestWhatsAppTemplateChooser:
     ) -> None:
         """Test that searching by slug returns matching templates."""
         response = admin_client.get(
-            "/admin/snippets/choose/home/whatsapptemplate/", {"q": "template-1"}
+            "/admin/snippets/choose/home/whatsapptemplate/",
+            {"q": "template-1-marketing"},
         )
         assert response.status_code == 200
         content = response.content.decode()

--- a/home/views.py
+++ b/home/views.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import django_filters
 import markdown
+from django.conf import settings
 from django.contrib import messages
 from django.db import connection as db_connection
 from django.db.models import Count, F, Q
@@ -83,7 +84,26 @@ class CustomIndexViewAssessment(SpreadsheetExportMixinAssessment, IndexViewAsses
 class CustomIndexViewWhatsAppTemplate(
     SpreadsheetExportMixinWhatsAppTemplate, IndexViewWhatsAppTemplate
 ):
-    pass
+    def search_queryset(self, queryset):
+        if not self.search_query:
+            return queryset
+
+        query = self.search_query.strip()
+        lowered_query = query.lower()
+
+        matching_language_codes = [
+            code
+            for code, language_name in settings.LANGUAGES
+            if lowered_query in code.lower() or lowered_query in language_name.lower()
+        ]
+
+        return queryset.filter(
+            Q(slug__icontains=query)
+            | Q(category__icontains=query)
+            | Q(message__icontains=query)
+            | Q(locale__language_code__icontains=query)
+            | Q(locale__language_code__in=matching_language_codes)
+        )
 
 
 class CustomIndexViewOrdered(SpreadsheetExportMixinOrdered, IndexViewOrdered):

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -287,7 +287,7 @@ class WhatsAppTemplateAdmin(SnippetViewSet):
         "slug",
         "category",
         "message",
-        "locale__language_code",
+        "locale",
     )
 
     index_view_class = CustomIndexViewWhatsAppTemplate


### PR DESCRIPTION
## Purpose
When searching on a WhatsApp Template, the search crashes because we're not indexing locale, and even when we do we need some custom logic to enable searching by locale.

## Solution
This PR fixes the indexing and adds the required custom logic

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
