### PR TITLE
Fix page search for Page / Contentpage combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix go_to_page item validation
 - Fix Ordered Content Set search
 - Fix WhatsApp Template search
+- Fix Page search for nested pages
 
 ### Security
 -->

--- a/home/models.py
+++ b/home/models.py
@@ -777,11 +777,6 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
                     return WhatsAppTemplate.objects.get(id=block["value"])
         return None
 
-    def get_descendants(self, inclusive: bool = False) -> Any:
-        # Keep Wagtail's default PageQuerySet behavior; narrowing this to
-        # ContentPage can break explorer search queryset combination.
-        return super().get_descendants(inclusive=inclusive)
-
     def _calc_avg_rating(self, ratings: Any) -> str:
         if ratings:
             helpful = 0

--- a/home/models.py
+++ b/home/models.py
@@ -778,7 +778,9 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
         return None
 
     def get_descendants(self, inclusive: bool = False) -> Any:
-        return ContentPage.objects.descendant_of(self, inclusive)
+        # Keep Wagtail's default PageQuerySet behavior; narrowing this to
+        # ContentPage can break explorer search queryset combination.
+        return super().get_descendants(inclusive=inclusive)
 
     def _calc_avg_rating(self, ratings: Any) -> str:
         if ratings:

--- a/home/tests/test_views.py
+++ b/home/tests/test_views.py
@@ -279,6 +279,31 @@ class TestEditPageView:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_explorer_search_on_content_page_parent(self, admin_client):
+        """
+        Explorer search should work on nested ContentPage parents.
+        """
+        home_page = HomePage.objects.first()
+        main_menu = home_page.get_children().filter(slug="main-menu").first()
+        if not main_menu:
+            main_menu = PageBuilder.build_cpi(home_page, "main-menu", "Main Menu")
+
+        parent = PageBuilder.build_cp(
+            parent=main_menu,
+            slug="parent-page",
+            title="Parent Page",
+            bodies=[WABody("Parent", [WABlk("Parent body")])],
+        )
+        PageBuilder.build_cp(
+            parent=parent,
+            slug="child-page",
+            title="Child Searchable",
+            bodies=[WABody("Child", [WABlk("Child body")])],
+        )
+
+        response = admin_client.get(f"/admin/pages/{parent.id}/", {"q": "child"})
+        assert response.status_code == status.HTTP_200_OK
+
     def test_contains_options_for_submission(self, admin_client):
         """
         The edit page has the option to Publish, Unpublish, Submit to Moderators approval or Save draft


### PR DESCRIPTION
## Purpose
Page search on is causing a Type Error: `Cannot combine queries on two different base models.`

This appears to be because `get_descendants()` returns a ContentPage and Explorer search internally combines querysets during filtering, which results in it trying to combine a Page and a ContentPage

## Solution
I added a test for it, and removed the custom `get_descendants` method, as we want the default behaviour.

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
