### PR TITLE
Fix live vs latest revision usage for Standalone templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Ordered Content Set search
 - Fix WhatsApp Template search
 - Fix Page search for nested pages
+- Standalone Templates corrctly use the current live version
 
 ### Security
 -->

--- a/home/api_v3.py
+++ b/home/api_v3.py
@@ -201,7 +201,6 @@ class ContentPagesV3APIViewset(PagesAPIViewSet):
         return self.process_detail_view(request, slug=slug)
 
     def listing_view(self, request, *args, **kwargs):
-
         channel = self.validate_channel()
         queryset = self.get_queryset()
         if channel:

--- a/home/models.py
+++ b/home/models.py
@@ -752,6 +752,9 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
             self.ratings.filter(revision=self.get_latest_revision())
         )
 
+    def get_live_revision_or_latest(self) -> Revision | None:
+        return self.live_revision or self.get_latest_revision()
+
     @property
     def has_whatsapp_template(self) -> bool:
         """
@@ -812,7 +815,7 @@ class ContentPage(UniqueSlugMixin, Page, ContentImportMixin):
                 data[key] = value
 
         page_view = {
-            "revision": self.get_latest_revision(),
+            "revision": self.get_live_revision_or_latest(),
             "data": data,
             "platform": f"{platform}",
         }
@@ -1681,5 +1684,11 @@ class WhatsAppTemplate(
             [b["value"]["title"] for b in self.buttons.raw_data],
         )
 
-    def create_whatsapp_template_name(self) -> str:
-        return f"{self.prefix}_{self.get_latest_revision().pk}"
+    def get_live_revision_or_latest(self) -> Revision | None:
+        return self.live_revision or self.get_latest_revision()
+
+    def create_whatsapp_template_name(self, revision: Revision | None = None) -> str:
+        revision = revision or self.get_live_revision_or_latest()
+        if revision is None:
+            raise ValidationError("Cannot create a template name without a revision.")
+        return f"{self.prefix}_{revision.pk}"

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -277,11 +277,13 @@ def body_field_representation(page: Any, request: Any) -> Any:
                             and "value" in formatted_message
                             and "message" in formatted_message["value"]
                         ):
-                            formatted_message["value"]["message"] = (
-                                latest_revision.whatsapp_body.raw_data[
-                                    message
-                                ]["value"]["message"]
-                            )  # Your modified message
+                            formatted_message["value"][
+                                "message"
+                            ] = latest_revision.whatsapp_body.raw_data[message][
+                                "value"
+                            ][
+                                "message"
+                            ]  # Your modified message
                     api_body.update(
                         [
                             (

--- a/home/serializers.py
+++ b/home/serializers.py
@@ -140,6 +140,15 @@ def format_whatsapp_template_message(message_index, content_page) -> dict[str, A
     return text
 
 
+def get_content_page_response_revision(page: ContentPage, request) -> int | None:
+    if request.GET.get("qa", "").lower() == "true":
+        revision = page.get_latest_revision()
+    else:
+        revision = page.get_live_revision_or_latest()
+
+    return revision.id if revision else None
+
+
 def format_whatsapp_message(message_index, content_page, platform):
     text = content_page.whatsapp_body._raw_data[message_index]
 
@@ -239,7 +248,10 @@ def body_field_representation(page: Any, request: Any) -> Any:
                                 "text",
                                 format_whatsapp_template_message(message, page),
                             ),
-                            ("revision", page.get_latest_revision().id),
+                            (
+                                "revision",
+                                get_content_page_response_revision(page, request),
+                            ),
                             ("is_whatsapp_template", True),
                             ("whatsapp_template_name", template.submission_name),
                             (
@@ -265,20 +277,21 @@ def body_field_representation(page: Any, request: Any) -> Any:
                             and "value" in formatted_message
                             and "message" in formatted_message["value"]
                         ):
-                            formatted_message["value"][
-                                "message"
-                            ] = latest_revision.whatsapp_body.raw_data[message][
-                                "value"
-                            ][
-                                "message"
-                            ]  # Your modified message
+                            formatted_message["value"]["message"] = (
+                                latest_revision.whatsapp_body.raw_data[
+                                    message
+                                ]["value"]["message"]
+                            )  # Your modified message
                     api_body.update(
                         [
                             (
                                 "text",
                                 formatted_message,
                             ),
-                            ("revision", page.get_latest_revision().id),
+                            (
+                                "revision",
+                                get_content_page_response_revision(page, request),
+                            ),
                             ("is_whatsapp_template", False),
                             ("whatsapp_template_name", ""),
                             ("whatsapp_template_category", "UTILITY"),

--- a/home/serializers_v3.py
+++ b/home/serializers_v3.py
@@ -247,7 +247,7 @@ class ContentPageSerializerV3(PageSerializer):
 class WhatsAppTemplateSerializer(serializers.ModelSerializer):
     slug = serializers.CharField(default="default-slug")
     locale = serializers.CharField(source="locale.language_code", default="en")
-    revision = serializers.IntegerField(source="get_latest_revision.id")
+    revision = serializers.SerializerMethodField()
     buttons = serializers.SerializerMethodField()
     example_values = serializers.SerializerMethodField(default=["Example Value 1"])
     detail_url = serializers.SerializerMethodField()
@@ -279,6 +279,16 @@ class WhatsAppTemplateSerializer(serializers.ModelSerializer):
             return super().to_representation(instance.get_latest_revision().as_object())
 
         return super().to_representation(instance)
+
+    def get_revision(self, obj):
+        request = self.context["request"]
+        return_drafts = request.query_params.get("return_drafts", "").lower() == "true"
+        if return_drafts:
+            revision = obj.get_latest_revision()
+        else:
+            revision = obj.get_live_revision_or_latest()
+
+        return revision.id if revision else None
 
     def get_buttons(self, obj):
         return format_buttons_and_list_items(obj.buttons.raw_data)

--- a/home/tests/test_api.py
+++ b/home/tests/test_api.py
@@ -503,6 +503,24 @@ class TestContentPageAPI:
         body = content["body"]["text"]["value"]["message"]
         assert body == "*Default whatsapp Content 1* 🏥"
 
+    def test_whatsapp_response_uses_live_revision_when_draft_exists(
+        self, uclient: Any
+    ) -> None:
+        page = self.create_content_page()
+        live_revision = page.live_revision
+
+        draft = page.get_latest_revision().as_object()
+        draft.whatsapp_body.raw_data[0]["value"]["message"] = "Draft whatsapp content"
+        draft_revision = draft.save_revision()
+
+        response = uclient.get(f"/api/v2/pages/{page.id}/?whatsapp=True")
+        content = response.json()
+
+        assert content["body"]["revision"] == live_revision.id
+        assert content["body"]["revision"] != draft_revision.id
+        body = content["body"]["text"]["value"]["message"]
+        assert body == "*Default whatsapp Content 1* 🏥"
+
     @pytest.mark.parametrize("platform", ALL_PLATFORMS_EXCL_WHATSAPP)
     def test_no_message_number_specified(self, uclient, platform):
         """

--- a/home/tests/test_api_v3.py
+++ b/home/tests/test_api_v3.py
@@ -899,9 +899,9 @@ class TestContentPageAPIV3:
             publish=True, title="Content Page 1", body_type=channel
         )
 
-        page.whatsapp_body[0].value["message"] = (
-            "Message changed in unpublished revision"
-        )
+        page.whatsapp_body[0].value[
+            "message"
+        ] = "Message changed in unpublished revision"
         page.save_revision()
 
         url = f"/api/v3/pages/?slug=content-page-1&channel={channel}&return_drafts=True"

--- a/home/tests/test_api_v3.py
+++ b/home/tests/test_api_v3.py
@@ -313,20 +313,23 @@ class TestWhatsAppTemplateAPIV3:
             locale="en",
             publish=True,
         )
+        live_revision = template.live_revision
 
         template.message = "Message changed in unpublished revision"
-        template.save_revision()
+        draft_revision = template.save_revision()
 
         url = f"/api/v3/whatsapptemplates/{template.id}/"
         response = uclient.get(url)
         content = response.json()
         assert content["message"] == "*Default published template 1* 🏥"
+        assert content["revision"] == live_revision.id
 
         url = f"/api/v3/whatsapptemplates/{template.id}/?return_drafts=true"
         response = uclient.get(url)
         content = response.json()
 
         assert content["message"] == "Message changed in unpublished revision"
+        assert content["revision"] == draft_revision.id
 
     def test_template_detail_buttons(self, uclient):
         """
@@ -896,9 +899,9 @@ class TestContentPageAPIV3:
             publish=True, title="Content Page 1", body_type=channel
         )
 
-        page.whatsapp_body[0].value[
-            "message"
-        ] = "Message changed in unpublished revision"
+        page.whatsapp_body[0].value["message"] = (
+            "Message changed in unpublished revision"
+        )
         page.save_revision()
 
         url = f"/api/v3/pages/?slug=content-page-1&channel={channel}&return_drafts=True"

--- a/home/tests/test_views.py
+++ b/home/tests/test_views.py
@@ -106,6 +106,27 @@ class TestPageRatings:
             "revision": page.get_latest_revision().id,
         }
 
+    def test_page_rating_uses_live_revision_when_draft_exists(self, api_client):
+        page = self.create_content_page()
+        live_revision = page.live_revision
+
+        draft = page.get_latest_revision().as_object()
+        draft.title = "Draft title"
+        draft_revision = draft.save_revision()
+
+        response = api_client.post(
+            "/api/v2/custom/ratings/",
+            {
+                "page": page.id,
+                "helpful": True,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["revision"] == live_revision.id
+        assert response.json()["revision"] != draft_revision.id
+
     def test_page_rating_required_fields(self, api_client):
         """
         Ensure that the helpful, page and revision fields are required
@@ -216,6 +237,22 @@ class TestPageViews:
             "platform": "web",
             "message": None,
         }
+
+    def test_page_view_uses_live_revision_when_draft_exists(self, api_client):
+        page = self.create_content_page()
+        live_revision = page.live_revision
+
+        draft = page.get_latest_revision().as_object()
+        draft.title = "Draft title"
+        draft_revision = draft.save_revision()
+
+        response = api_client.get(f"/api/v2/pages/{page.id}/?whatsapp=True")
+
+        assert response.status_code == status.HTTP_200_OK
+        page_view = PageView.objects.latest("id")
+        assert page_view.page_id == page.id
+        assert page_view.revision_id == live_revision.id
+        assert page_view.revision_id != draft_revision.id
 
 
 @pytest.mark.django_db

--- a/home/tests/test_whatsapp.py
+++ b/home/tests/test_whatsapp.py
@@ -281,7 +281,9 @@ class DummyRevisionObj:
         self.submission_result: str = ""
         self.SubmissionStatus = DummySubmissionStatus
 
-    def create_whatsapp_template_name(self, revision: DummyRevision | None = None) -> str:
+    def create_whatsapp_template_name(
+        self, revision: "DummyRevision" | None = None
+    ) -> str:
         return "template_123"
 
     def save(self) -> None:
@@ -310,7 +312,9 @@ class DummyModel:
     def get_latest_revision(self) -> DummyRevision | None:
         return self._revision
 
-    def create_whatsapp_template_name(self, revision: DummyRevision | None = None) -> str:
+    def create_whatsapp_template_name(
+        self, revision: DummyRevision | None = None
+    ) -> str:
         return "template_123"
 
     def save(self) -> None:

--- a/home/tests/test_whatsapp.py
+++ b/home/tests/test_whatsapp.py
@@ -281,7 +281,7 @@ class DummyRevisionObj:
         self.submission_result: str = ""
         self.SubmissionStatus = DummySubmissionStatus
 
-    def create_whatsapp_template_name(self) -> str:
+    def create_whatsapp_template_name(self, revision=None) -> str:
         return "template_123"
 
     def save(self) -> None:
@@ -310,7 +310,7 @@ class DummyModel:
     def get_latest_revision(self) -> DummyRevision | None:
         return self._revision
 
-    def create_whatsapp_template_name(self) -> str:
+    def create_whatsapp_template_name(self, revision=None) -> str:
         return "template_123"
 
     def save(self) -> None:
@@ -391,17 +391,23 @@ def test_submit_revision(monkeypatch: pytest.MonkeyPatch) -> None:
         example_values=[("example_values", "Ev1"), ("example_values", "Ev2")],
     )
     wat.save()
-    wat.save_revision().publish()
-    rev1 = wat.get_latest_revision().as_object()
-    latest_revision = wat.get_latest_revision().as_object()
-    assert rev1.category == "UTILITY"
-    latest_revision.category = "MARKETING"
-    latest_revision.save_revision()
+    live_revision = wat.save_revision()
+    live_revision.publish()
+    live_obj = live_revision.as_object()
+    draft = live_revision.as_object()
+    assert live_obj.category == "UTILITY"
+    draft.category = "MARKETING"
+    rev2 = draft.save_revision()
 
-    assert wat.category == rev1.category == "UTILITY"
+    newer_draft = rev2.as_object()
+    newer_draft.category = "UTILITY"
+    rev3 = newer_draft.save_revision()
+    wat.refresh_from_db()
 
-    rev2 = wat.revisions.order_by("-created_at").first()
-    pk = rev2.id
+    assert wat.category == live_obj.category == "UTILITY"
+    assert wat.get_latest_revision().id == rev3.id
+    assert rev2.id != rev3.id
+
     rev_object = rev2.as_object()
     assert rev_object.category == "MARKETING"
 
@@ -417,13 +423,54 @@ def test_submit_revision(monkeypatch: pytest.MonkeyPatch) -> None:
 
     submit_to_meta_action(rev2)
 
-    rev3 = wat.revisions.order_by("-created_at").first()
-    rev3_obj = rev3.as_object()
-    assert rev3_obj.submission_name == f"valid_named_variables_{pk}"
-    assert rev3_obj.submission_status == DummySubmissionStatus.SUBMITTED
-    assert rev3_obj.submission_result.startswith("Success! Template ID = ")
+    submitted_revision = wat.revisions.order_by("-created_at").first()
+    submitted_obj = submitted_revision.as_object()
+    assert submitted_obj.submission_name == f"valid_named_variables_{rev2.pk}"
+    assert submitted_obj.submission_status == DummySubmissionStatus.SUBMITTED
+    assert submitted_obj.submission_result.startswith("Success! Template ID = ")
 
     wat = WhatsAppTemplate.objects.filter(live=True).first()
     latest_rev = wat.revisions.order_by("-created_at").first().as_object()
-    assert wat.category == rev1.category
+    assert wat.category == live_obj.category
     assert wat.category != latest_rev.category
+
+
+@pytest.mark.django_db
+def test_submit_template_uses_live_revision_when_newer_draft_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wat = WhatsAppTemplate(
+        slug="valid-named-variables",
+        message="This is a message with 2 valid named vars {{1}} and {{2}}",
+        category="UTILITY",
+        locale=Locale.objects.get(language_code="en"),
+        example_values=[("example_values", "Ev1"), ("example_values", "Ev2")],
+    )
+    wat.save()
+    live_revision = wat.save_revision()
+    live_revision.publish()
+    wat.refresh_from_db()
+
+    draft = wat.get_latest_revision().as_object()
+    draft.category = "MARKETING"
+    draft_revision = draft.save_revision()
+    wat.refresh_from_db()
+
+    assert wat.live_revision_id == live_revision.id
+    assert wat.get_latest_revision().id == draft_revision.id
+
+    def fake_create_standalone_whatsapp_template(
+        **kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {"id": "fakeid123"}
+
+    monkeypatch.setattr(
+        "home.whatsapp.create_standalone_whatsapp_template",
+        fake_create_standalone_whatsapp_template,
+    )
+
+    submit_to_meta_action(wat)
+
+    wat.refresh_from_db()
+    assert wat.submission_name == f"valid_named_variables_{live_revision.id}"
+    assert wat.submission_status == DummySubmissionStatus.SUBMITTED

--- a/home/tests/test_whatsapp.py
+++ b/home/tests/test_whatsapp.py
@@ -282,7 +282,7 @@ class DummyRevisionObj:
         self.SubmissionStatus = DummySubmissionStatus
 
     def create_whatsapp_template_name(
-        self, revision: "DummyRevision" | None = None
+        self, revision: "DummyRevision | None" = None
     ) -> str:
         return "template_123"
 

--- a/home/tests/test_whatsapp.py
+++ b/home/tests/test_whatsapp.py
@@ -281,7 +281,7 @@ class DummyRevisionObj:
         self.submission_result: str = ""
         self.SubmissionStatus = DummySubmissionStatus
 
-    def create_whatsapp_template_name(self, revision=None) -> str:
+    def create_whatsapp_template_name(self, revision: DummyRevision | None = None) -> str:
         return "template_123"
 
     def save(self) -> None:
@@ -310,7 +310,7 @@ class DummyModel:
     def get_latest_revision(self) -> DummyRevision | None:
         return self._revision
 
-    def create_whatsapp_template_name(self, revision=None) -> str:
+    def create_whatsapp_template_name(self, revision: DummyRevision | None = None) -> str:
         return "template_123"
 
     def save(self) -> None:

--- a/home/views.py
+++ b/home/views.py
@@ -692,7 +692,7 @@ class ContentPageRatingViewSet(GenericListViewset, CreateModelMixin):
             try:
                 page = ContentPage.objects.get(id=request.data["page"])
                 # FIXME: why are we altering the request data here
-                request.data["revision"] = page.get_latest_revision().id
+                request.data["revision"] = page.get_live_revision_or_latest().id
             except ContentPage.DoesNotExist:
                 raise ValidationError({"page": ["Page matching query does not exist."]})
 

--- a/home/whatsapp.py
+++ b/home/whatsapp.py
@@ -351,11 +351,12 @@ def create_standalone_template_header_components(
 
 
 def submit_to_meta_action(template: "WhatsAppTemplate | Revision") -> None:
-    is_revision = isinstance(template, Revision)
-    if is_revision:
-        template = template.as_object()
+    revision = template if isinstance(template, Revision) else None
+    is_revision = revision is not None
+    if revision:
+        template = revision.as_object()
 
-    template_name = template.create_whatsapp_template_name()
+    template_name = template.create_whatsapp_template_name(revision=revision)
     try:
         response_json = create_standalone_whatsapp_template(
             name=template_name,


### PR DESCRIPTION
## Purpose
While going through Alovida we discovered that the Pages templating system assumed the latest Page would always be the Template to use, which means if you rollback then things break. It turns out this is also similar for Standalone Templates.

## Solution
This uses the current live version as the version to use rather than preferring the latest, unless we're asking about draft version.

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
