### PR TITLE
Add meta language codes for different chinese dialects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!--
 ## Unreleased
 ### Added
-- Added additional languages for translations (Afrikaans, isiNdebele, Pedi, Sesotho, siSwati, Setswana, Xitsonga, Tshivenda, isiXhosa, isiZulu)
+- Added additional languages for translations (Afrikaans, isiNdebele, Pedi, Sesotho, siSwati, Setswana, Xitsonga, Tshivenda, isiXhosa, isiZulu, Chinese)
 
 ### Changed
 

--- a/contentrepo/settings/base.py
+++ b/contentrepo/settings/base.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 import dj_database_url
-import environ
+import environ  # type: ignore[import-untyped]
 
 env = environ.Env()
 
@@ -158,6 +158,9 @@ WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
     ("id", "Bahasa"),
     ("bn", "Bangla"),
     ("zh", "Chinese"),
+    ("zh_CN", "Chinese (CHN)"),
+    ("zh_HK", "Chinese (HKG)"),
+    ("zh_TW", "Chinese (TAI)"),
     ("prs", "Dari"),
     ("en", "English"),
     ("fr", "French"),

--- a/home/tests/import-export-data/whatsapp-template-chinese-dialects.csv
+++ b/home/tests/import-export-data/whatsapp-template-chinese-dialects.csv
@@ -1,0 +1,4 @@
+slug,category,buttons,language_code,image,message,example_values,submission_name,submission_status,submission_result
+test-template-zh-cn,MARKETING,[],zh_CN,,Chinese mainland message,,,,
+test-template-zh-hk,MARKETING,[],zh_HK,,Hong Kong Chinese message,,,,
+test-template-zh-tw,MARKETING,[],zh_TW,,Taiwan Chinese message,,,,

--- a/home/tests/test_whatsapp_template_import_export.py
+++ b/home/tests/test_whatsapp_template_import_export.py
@@ -639,6 +639,28 @@ class TestImportExport:
         assert e.value.row_num == 2
         assert e.value.message == ["Language code not found: fakecode"]
 
+    def test_import_chinese_dialect_language_codes(
+        self, csv_impexp: ImportExport
+    ) -> None:
+        """
+        Importing whatsapp templates with configured Chinese dialect language codes should work.
+        """
+        expected_templates = {
+            "test-template-zh-cn": "zh_CN",
+            "test-template-zh-hk": "zh_HK",
+            "test-template-zh-tw": "zh_TW",
+        }
+        for language_code in expected_templates.values():
+            Locale.objects.get_or_create(language_code=language_code)
+
+        csv_impexp.import_file("whatsapp-template-chinese-dialects.csv")
+
+        assert WhatsAppTemplate.objects.count() == len(expected_templates)
+        for slug, language_code in expected_templates.items():
+            assert WhatsAppTemplate.objects.filter(
+                slug=slug, locale__language_code=language_code
+            ).exists()
+
     def test_go_to_page_button_missing_page(self, csv_impexp: ImportExport) -> None:
         """
         Go to page buttons in the import file link to other pages using the slug. But


### PR DESCRIPTION
## Purpose
WHO needs to send chinese translations, and CMS doesn't support the same language codes that Meta expects.

## Solution
I added the chinese language dialect codes

#### Checklist
- [x] Added or updated unit tests
- [x] Added to release notes
- [ ] Updated readme/documentation (if necessary)
- [ ] Add support to FakeCMS in the [flow tester](https://github.com/praekeltfoundation/flow_tester) (if necessary)
